### PR TITLE
Refactor urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,23 @@ Add the urls to your `ROOT_URLCONF`
         ...
     )
 
-If you are using the `VerifyEmailMixin` then replace `user_management.api.url`
-with `user_management.api.verify_email_urls`
+If you are using the `VerifyEmailMixin` then also include
+`user_management.api.urls.verify_email`
 
     urlpatterns = patterns(''
         ...
-        url('', include('user_management.api.verify_email_urls')),
+        url('', include('user_management.api.urls.verify_email')),
+        ...
+    )
+
+If you need more fine-grained control you can replace `user_management.api.urls`
+with a selection from
+
+    urlpatterns = patterns(''
+        ...
+        url('', include('user_management.api.urls.auth')),
+        url('', include('user_management.api.urls.password_reset')),
+        url('', include('user_management.api.urls.profile')),
+        url('', include('user_management.api.urls.register')),
         ...
     )

--- a/user_management/api/tests/urls.py
+++ b/user_management/api/tests/urls.py
@@ -2,5 +2,6 @@ from django.conf.urls import include, patterns, url
 
 
 urlpatterns = patterns('',
-    url(r'', include('user_management.api.verify_email_urls')),
+    url(r'', include('user_management.api.urls')),
+    url(r'', include('user_management.api.urls.verify_email')),
 )

--- a/user_management/api/urls/__init__.py
+++ b/user_management/api/urls/__init__.py
@@ -1,0 +1,10 @@
+from django.conf.urls import include, patterns, url
+
+
+urlpatterns = patterns(
+    '',
+    url(r'', include('user_management.api.urls.auth')),
+    url(r'', include('user_management.api.urls.password_reset')),
+    url(r'', include('user_management.api.urls.profile')),
+    url(r'', include('user_management.api.urls.register')),
+)

--- a/user_management/api/urls/auth.py
+++ b/user_management/api/urls/auth.py
@@ -1,0 +1,13 @@
+from django.conf.urls import patterns, url
+
+from .. import views
+
+
+urlpatterns = patterns(
+    '',
+    url(
+        regex=r'^auth/?$',
+        view=views.GetToken.as_view(),
+        name='auth',
+    ),
+)

--- a/user_management/api/urls/password_reset.py
+++ b/user_management/api/urls/password_reset.py
@@ -1,16 +1,11 @@
 from django.conf.urls import patterns, url
 from django.views.decorators.csrf import csrf_exempt
 
-from . import views
+from .. import views
 
 
 urlpatterns = patterns(
     '',
-    url(
-        regex=r'^auth/?$',
-        view=views.GetToken.as_view(),
-        name='auth',
-    ),
     url(
         regex=r'^auth/password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         view=csrf_exempt(views.PasswordResetView.as_view()),
@@ -20,15 +15,5 @@ urlpatterns = patterns(
         regex=r'^auth/password_reset/$',
         view=views.PasswordResetEmailView.as_view(),
         name='password_reset',
-    ),
-    url(
-        regex=r'^profile/$',
-        view=views.ProfileDetailView.as_view(),
-        name='profile_detail',
-    ),
-    url(
-        regex=r'^profile/password/$',
-        view=views.PasswordChangeView.as_view(),
-        name='password_change',
     ),
 )

--- a/user_management/api/urls/profile.py
+++ b/user_management/api/urls/profile.py
@@ -1,0 +1,19 @@
+from django.conf.urls import patterns, url
+from django.views.decorators.csrf import csrf_exempt
+
+from .. import views
+
+
+urlpatterns = patterns(
+    '',
+    url(
+        regex=r'^profile/$',
+        view=views.ProfileDetailView.as_view(),
+        name='profile_detail',
+    ),
+    url(
+        regex=r'^profile/password/$',
+        view=views.PasswordChangeView.as_view(),
+        name='password_change',
+    ),
+)

--- a/user_management/api/urls/register.py
+++ b/user_management/api/urls/register.py
@@ -1,0 +1,13 @@
+from django.conf.urls import patterns, url
+
+from .. import views
+
+
+urlpatterns = patterns(
+    '',
+    url(
+        regex=r'^register/?$',
+        view=views.UserRegister.as_view(),
+        name='register',
+    ),
+)

--- a/user_management/api/urls/verify_email.py
+++ b/user_management/api/urls/verify_email.py
@@ -1,11 +1,10 @@
 from django.conf.urls import patterns, url
 from django.views.decorators.csrf import csrf_exempt
 
-from .urls import urlpatterns
-from . import views
+from .. import views
 
 
-urlpatterns += patterns(
+urlpatterns = patterns(
     '',
     url(
         regex=r'^verify_email/(?P<uidb64>[0-9A-Za-z_\-]+)/(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',


### PR DESCRIPTION
As views will likely be overridden in a lot of projects, we should facilitate this by making the `urls` more modular.

The base `urls,py` should `include()`
- [x] `verify_email_urls` (already exists)
- [x] `auth_urls` (get_token)
- [x] `password_reset_urls` (both of)
- [x] `profile_urls` (both of)
