### PR TITLE
Missing dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,3 @@ env:
 install:
   - psql -c 'CREATE DATABASE user_management' -U postgres;
   - pip install -r test_requirements.txt
-  - pip install -e .

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
+-e .
 django==1.6.1
 factory_boy==2.3.1
 psycopg2==2.5.2


### PR DESCRIPTION
When using pip to install the requirements we have a `No module named incuna_mail`
