### PR TITLE
Add note about Authentication to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Add to your `INSTALLED_APPS` in `settings.py`
         ...
     )
 
+Set your `DEFAULT_AUTHENTICATION_CLASSES`, for example:
+
+    REST_FRAMEWORK = {
+        'DEFAULT_AUTHENTICATION_CLASSES': {
+            'rest_framework.authentication.TokenAuthentication',
+            'rest_framework.authentication.SessionAuthentication',
+        },
+    }
+
 Add the urls to your `ROOT_URLCONF`
 
     urlpatterns = patterns(''

--- a/user_management/tests/run.py
+++ b/user_management/tests/run.py
@@ -31,10 +31,6 @@ settings.configure(
     REST_FRAMEWORK={
         'DEFAULT_AUTHENTICATION_CLASSES': (
             'rest_framework.authentication.TokenAuthentication',
-            'rest_framework.authentication.SessionAuthentication',
-        ),
-        'DEFAULT_RENDERER_CLASSES': (
-            'rest_framework.renderers.JSONRenderer',
         ),
     },
 )


### PR DESCRIPTION
Add example `DEFAULT_AUTHENTICATION_CLASSES` to README. Remove unnecessary `REST_FRAMEWORK` settings from test runner.
