### PR TITLE
VerifyAccount should return a message and a 201

### DIFF
--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -353,7 +353,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post', auth=True)
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
         self.assertTrue(updated_user.verified_email)
@@ -367,7 +367,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
         self.assertTrue(updated_user.verified_email)
@@ -412,7 +412,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post', user=other_user)
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
         self.assertTrue(updated_user.verified_email)

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -113,6 +113,7 @@ class PasswordChange(generics.UpdateAPIView):
 
 class VerifyAccountView(OneTimeUseAPIMixin, views.APIView):
     permission_classes = [AllowAny]
+    ok_message = _('Your account has been verified.')
 
     def post(self, request, *args, **kwargs):
         if self.user.verified_email:
@@ -121,7 +122,11 @@ class VerifyAccountView(OneTimeUseAPIMixin, views.APIView):
         self.user.verified_email = True
         self.user.is_active = True
         self.user.save()
-        return response.Response(status=status.HTTP_200_OK)
+
+        return response.Response(
+            data={'data': self.ok_message},
+            status=status.HTTP_201_CREATED,
+        )
 
 
 class ProfileDetail(generics.RetrieveUpdateAPIView):


### PR DESCRIPTION
At the moment when verifying an account response contains a 200 and no data.
https://github.com/incuna/django-user-management/blob/master/user_management/api/views.py#L125
