### PR TITLE
Add DELETE method to /auth/

### DIFF
--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -7,6 +7,7 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from mock import patch
 from rest_framework import status
+from rest_framework.authtoken.models import Token
 
 from user_management.api import views
 from user_management.models.tests.factories import UserFactory
@@ -16,6 +17,21 @@ from user_management.models.tests.utils import APIRequestTestCase
 
 User = get_user_model()
 TEST_SERVER = 'http://testserver'
+
+
+class GetTokenTest(APIRequestTestCase):
+    view_class = views.GetToken
+
+    def test_delete(self):
+        user = UserFactory.create()
+        token = Token.objects.create(user=user)
+
+        request = self.create_request('delete', user=user)
+        response = self.view_class.as_view()(request)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        with self.assertRaises(Token.DoesNotExist):
+            Token.objects.get(pk=token.pk)
 
 
 class TestRegisterView(APIRequestTestCase):

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -6,6 +6,7 @@ from django.utils.http import urlsafe_base64_encode, urlsafe_base64_decode
 from django.utils.translation import ugettext_lazy as _
 from incuna_mail import send
 from rest_framework import generics, renderers, response, status, views
+from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
@@ -17,6 +18,15 @@ User = get_user_model()
 
 class GetToken(ObtainAuthToken):
     renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer)
+
+    def delete(self, request, *args, **kwargs):
+        try:
+            token = Token.objects.get(user=request.user)
+        except Token.DoesNotExist:
+            pass
+        else:
+            token.delete()
+        return response.Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class UserRegister(generics.CreateAPIView):

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -72,6 +72,7 @@ class TestUser(TestCase):
             'groups',  # Django permission groups
             'user_permissions',
             'logentry',  # Django admin logs
+            'auth_token',  # Rest framework authtoken
         }
 
         try:

--- a/user_management/tests/run.py
+++ b/user_management/tests/run.py
@@ -21,6 +21,8 @@ settings.configure(
         'django.contrib.sessions',
         'django.contrib.admin',
 
+        'rest_framework.authtoken',
+
         # Added for templates
         'user_management.api',
         'user_management.models.tests',


### PR DESCRIPTION
Authenticated `DELETE` requests to `/auth/` should invalidate the session linked to that token.
