### PR TITLE
Authentication raises a 500 when the token is created (during first login)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ version = '1.2.0'
 
 
 install_requires = (
-    'djangorestframework>=2.3.13,<3',
+    'djangorestframework>=2.3.14,<3',
     'incuna_mail>=0.2,<0.3',
 )
 


### PR DESCRIPTION
There appears to be a bug in drf when creating tokens (in Python 3)

The issue is mentioned in https://github.com/tomchristie/django-rest-framework/pull/1382

The error in sentry is http://sentry.incuna.com/default/bydureon-epatientincunatestingcom/group/45/

We could fix this in this app but it would be better to get it fixed in drf.
