### PR TITLE
Add default throttle rates for login and password

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,8 +138,13 @@ with a selection from
 The `/auth/` and `/auth/password_reset/` URLs are protected against throttling
 using the built-in [DRF throttle module](http://www.django-rest-framework.org/api-guide/throttling).
 
-You need to set the throttling rates in `DEFAULT_THROTTLE_RATES` setting for
-`REST_FRAMEWORK` in your `settings.py`:
+The default throttle rates are:
+    
+    'logins': '10/hour'
+    'passwords': '3/hour'
+
+You can customise the throttling rates by setting `DEFAULT_THROTTLE_RATES`
+in your `settings.py`:
 
     DEFAULT_THROTTLE_RATES = {
         'logins': '100/day',

--- a/user_management/api/throttling.py
+++ b/user_management/api/throttling.py
@@ -1,0 +1,17 @@
+from rest_framework.throttling import ScopedRateThrottle
+
+
+class DefaultRateMixin(object):
+    def get_rate(self):
+        try:
+            return self.THROTTLE_RATES[self.scope]
+        except KeyError:
+            return self.default_rate
+
+
+class LoginRateThrottle(DefaultRateMixin, ScopedRateThrottle):
+    default_rate = '10/hour'
+
+
+class PasswordResetRateThrottle(DefaultRateMixin, ScopedRateThrottle):
+    default_rate = '3/hour'

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -10,9 +10,8 @@ from rest_framework import generics, renderers, response, status, views
 from rest_framework.authtoken.models import Token
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
-from rest_framework.throttling import ScopedRateThrottle
 
-from . import serializers, permissions
+from . import permissions, serializers, throttling
 
 
 User = get_user_model()
@@ -20,7 +19,7 @@ User = get_user_model()
 
 class GetToken(ObtainAuthToken):
     renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer)
-    throttle_classes = [ScopedRateThrottle]
+    throttle_classes = [throttling.LoginRateThrottle]
     throttle_scope = 'logins'
 
     def delete(self, request, *args, **kwargs):
@@ -70,7 +69,7 @@ class PasswordResetEmail(generics.GenericAPIView):
     permission_classes = [permissions.IsNotAuthenticated]
     template_name = 'user_management/password_reset_email.html'
     serializer_class = serializers.PasswordResetEmailSerializer
-    throttle_classes = [ScopedRateThrottle]
+    throttle_classes = [throttling.PasswordResetRateThrottle]
     throttle_scope = 'passwords'
 
     def email_context(self, site, user):

--- a/user_management/tests/run.py
+++ b/user_management/tests/run.py
@@ -39,10 +39,6 @@ settings.configure(
         'DEFAULT_AUTHENTICATION_CLASSES': (
             'rest_framework.authentication.TokenAuthentication',
         ),
-        'DEFAULT_THROTTLE_RATES': {
-            'logins': '100/day',
-            'passwords': '100/day',
-        }
     },
 )
 


### PR DESCRIPTION
We should add sane defaults so these views are protected by default.
