### PR TITLE
Fix intermittent circular imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ version = '1.2.0'
 
 install_requires = (
     'djangorestframework>=2.3.14,<3',
-    'incuna_mail>=0.2,<0.3',
+    'incuna_mail>=1.0.0,<2',
 )
 
 extras_require = {


### PR DESCRIPTION
The new version of incuna-mail no longer calls get_user_model, so we avoid a
circular import with this upgrade.
