### PR TITLE
Fix bug where get_fieldsets is called twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming Release
+
+* Fix bug where VerifyUserAdmin.get_fieldsets is called twice
+
 ## v1.2.1
 
 * Bump required version of `incuna-mail` in order to fix circular import.

--- a/user_management/models/admin.py
+++ b/user_management/models/admin.py
@@ -55,7 +55,13 @@ class VerifyUserAdmin(UserAdmin):
         except KeyError:
             return fieldsets
 
-        index = fields.index('is_active')
+        try:
+            index = fields.index('is_active')
+        except ValueError:
+            # If get_fieldsets is called twice, 'is_active' will already be
+            # removed and fieldsets will be correct so return it
+            return fieldsets
+
         fields[index] = ('is_active', 'email_verification_required')
         fieldsets_dict['Permissions']['fields'] = tuple(fields)
         return tuple(fieldsets_dict.items())

--- a/user_management/models/tests/test_admin.py
+++ b/user_management/models/tests/test_admin.py
@@ -48,3 +48,9 @@ class VerifyUserAdminTest(TestCase):
             verify_user_admin.get_fieldsets(request=None, obj=user),
             expected_fieldsets,
         )
+
+        # Django admin can call get_fieldsets twice, so check we don't break
+        self.assertEqual(
+            verify_user_admin.get_fieldsets(request=None, obj=user),
+            expected_fieldsets,
+        )


### PR DESCRIPTION
- If get_fieldsets is called twice, the 'is_active' field will already
  have been replaced by ('is_active', 'email_verification_required')
- Reverts 49105af
