### PR TITLE
Fix DEFAULT_THROTTLE_RATES section of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The default throttle rates are:
     'logins': '10/hour'
     'passwords': '3/hour'
 
-You can customise the throttling rates by setting `REST_FRAMEWORK.DEFAULT_THROTTLE_RATES`
+You can customise the throttling rates by setting `REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']`
 in your `settings.py`:
 
     REST_FRAMEWORK = {


### PR DESCRIPTION
Fix the README to use `REST_FRAMEWORK.DEFAULT_THROTTLE_RATES` 
