### PR TITLE
Use `get_by_natural_key` for `ValidateEmailMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Upcoming
+
+* Get user by natural key in `ValidateEmailMixin`.
+
 ## v3.5.2
 
 * Get user by natural key in `PasswordResetEmail`.

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -14,7 +14,7 @@ class ValidateEmailMixin(object):
         email = attrs.get(source).lower()
 
         try:
-            User.objects.get(email__iexact=email)
+            User.objects.get_by_natural_key(email)
         except User.DoesNotExist:
             attrs[source] = email
             return attrs

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -197,7 +197,7 @@ class TestRegisterView(APIRequestTestCase):
 
         self.assertTrue('email' in response.data, msg=response.data)
 
-        self.assertFalse(User.objects.count() > 1)
+        self.assertEqual(User.objects.count(), 1)
 
 
 class TestPasswordResetEmail(APIRequestTestCase):


### PR DESCRIPTION
Following #92 and regarding the django authenticate method it would help to change the [`ValidateEmailMixin`](https://github.com/incuna/django-user-management/blob/f3ec4d81d7cad37ac6ebb0860a1aa1331740662e/user_management/api/serializers.py#L17) to use `get_by_natural_key` to check if an user exists on registration.