### PR TITLE
Add a view to resend a confirmation email.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.1.0 (Upcoming)
+
+* Add `ResendConfirmationEmail` view.
+
 ## v4.0.1
 
 * Remove calculation in translatable string

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -173,12 +173,12 @@ class ResendConfirmationEmailSerializer(EmailSerializerBase):
         """Check if user exists and email_verification_required."""
         email = attrs[source]
         try:
-            user = User.objects.get_by_natural_key(email)
+            self.user = User.objects.get_by_natural_key(email)
         except User.DoesNotExist:
             msg = _('User does not exists.')
             raise serializers.ValidationError(msg)
 
-        if not user.email_verification_required:
+        if not self.user.email_verification_required:
             msg = _('User is already confirmed.')
             raise serializers.ValidationError(msg)
         return attrs

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -170,7 +170,10 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 class ResendConfirmationEmailSerializer(EmailSerializerBase):
     def validate_email(self, attrs, source):
-        """Check if user exists and email_verification_required."""
+        """Validate if email exists and requires a verification.
+
+        `validate_email` will set a `user` attribute on the instance allowing
+        the view to send an email confirmation."""
         email = attrs[source]
         try:
             self.user = User.objects.get_by_natural_key(email)

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -26,6 +26,7 @@ class ValidateEmailMixin(object):
 
 
 class EmailSerializerBase(serializers.Serializer):
+    """Serializer defining a read-only `email` field."""
     email = serializers.EmailField(max_length=511, label=_('Email address'))
 
     class Meta:
@@ -158,7 +159,7 @@ class PasswordResetSerializer(serializers.ModelSerializer):
 
 
 class PasswordResetEmailSerializer(EmailSerializerBase):
-    pass
+    """Serializer defining an `email` field to reset password."""
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -169,6 +170,7 @@ class ProfileSerializer(serializers.ModelSerializer):
 
 
 class ResendConfirmationEmailSerializer(EmailSerializerBase):
+    """Serializer defining an `email` field to resend a confirmation email."""
     def validate_email(self, attrs, source):
         """Validate if email exists and requires a verification.
 

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -175,11 +175,11 @@ class ResendConfirmationEmailSerializer(EmailSerializerBase):
         try:
             self.user = User.objects.get_by_natural_key(email)
         except User.DoesNotExist:
-            msg = _('User does not exists.')
+            msg = _('A user with this email address does not exist.')
             raise serializers.ValidationError(msg)
 
         if not self.user.email_verification_required:
-            msg = _('User is already confirmed.')
+            msg = _('User email address is already verified.')
             raise serializers.ValidationError(msg)
         return attrs
 

--- a/user_management/api/tests/test_serializers.py
+++ b/user_management/api/tests/test_serializers.py
@@ -326,3 +326,25 @@ class SerializerPasswordsTest(TestCase):
         for serializer_class, field in self.serializers:
             data = {field: 'AAAaaa11'}
             self.assert_no_validation_error(serializer_class, field, data)
+
+
+class ResendConfirmationEmailSerializerTest(TestCase):
+    def test_serialize(self):
+        """Assert user can request a new email confirmation."""
+        user = UserFactory.create()
+        data = {'email': user.email}
+        serializer = serializers.ResendConfirmationEmailSerializer(data=data)
+        self.assertTrue(serializer.is_valid(), msg=serializer.errors)
+
+    def test_user_does_not_exist(self):
+        """Assert user should exist before sending email confirmation."""
+        data = {'email': 'a-non-existing@user.com'}
+        serializer = serializers.ResendConfirmationEmailSerializer(data=data)
+        self.assertFalse(serializer.is_valid())
+
+    def test_user_already_validated(self):
+        """Assert confirmation email is not send if user was already verified."""
+        user = UserFactory.create(email_verification_required=False)
+        data = {'email': user.email}
+        serializer = serializers.ResendConfirmationEmailSerializer(data=data)
+        self.assertFalse(serializer.is_valid())

--- a/user_management/api/tests/test_throttling.py
+++ b/user_management/api/tests/test_throttling.py
@@ -96,3 +96,19 @@ class TestPasswordResetEmail(APIRequestTestCase):
         # request is throttled
         response = view(request)
         self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+
+class TestResendConfirmationEmail(APIRequestTestCase):
+    view_class = views.ResendConfirmationEmail
+
+    @patch(THROTTLE_RATE_PATH, new={'confirmations': '0/minute'})
+    def test_post_rate_limit(self):
+        """Assert POST requests are rate limited."""
+        user = UserFactory.create()
+        data = {'email': user.email}
+
+        request = self.create_request('post', data=data, auth=False)
+        view = self.view_class.as_view()
+
+        response = view(request)
+        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)

--- a/user_management/api/tests/test_throttling.py
+++ b/user_management/api/tests/test_throttling.py
@@ -12,12 +12,15 @@ THROTTLE_RATE_PATH = 'rest_framework.throttling.ScopedRateThrottle.THROTTLE_RATE
 
 
 class ClearCacheMixin:
+    """Clear cache on `tearDown`.
+
+    `django-rest-framework` puts a successful (not throttled) request into a cache."""
     def tearDown(self):
-        # DRF puts a successful (not throttled) request into a cache
         cache.clear()
 
 
 class GetAuthTokenTest(ClearCacheMixin, APIRequestTestCase):
+    """Test `GetAuthToken` is throttled."""
     throttle_expected_status = status.HTTP_429_TOO_MANY_REQUESTS
     view_class = views.GetAuthToken
 
@@ -76,6 +79,7 @@ class GetAuthTokenTest(ClearCacheMixin, APIRequestTestCase):
 
 
 class TestPasswordResetEmail(ClearCacheMixin, APIRequestTestCase):
+    """Test `PasswordResetEmail` is throttled."""
     view_class = views.PasswordResetEmail
 
     @patch(THROTTLE_RATE_PATH, new={'passwords': '1/minute'})
@@ -97,6 +101,7 @@ class TestPasswordResetEmail(ClearCacheMixin, APIRequestTestCase):
 
 
 class TestResendConfirmationEmail(ClearCacheMixin, APIRequestTestCase):
+    """Test `ResendConfirmationEmail` is throttled."""
     view_class = views.ResendConfirmationEmail
 
     @patch(THROTTLE_RATE_PATH, new={'confirmations': '1/minute'})

--- a/user_management/api/tests/test_throttling.py
+++ b/user_management/api/tests/test_throttling.py
@@ -118,4 +118,8 @@ class TestResendConfirmationEmail(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         response = view(request)
-        self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_429_TOO_MANY_REQUESTS,
+            msg=response.data,
+        )

--- a/user_management/api/tests/test_urls.py
+++ b/user_management/api/tests/test_urls.py
@@ -57,6 +57,7 @@ class TestURLs(URLTestCase):
             url_name='user_management_api:user_list')
 
     def test_verify_email(self):
+        """Assert `verify_user` is defined."""
         uidb64 = '123'
         token = 'a-token'
         self.assert_url_matches_view(
@@ -67,6 +68,7 @@ class TestURLs(URLTestCase):
         )
 
     def test_resend_confirmation_email(self):
+        """Assert `resend_confirmation_email` is defined."""
         self.assert_url_matches_view(
             view=views.ResendConfirmationEmail,
             expected_url='/resend-confirmation-email',

--- a/user_management/api/tests/test_urls.py
+++ b/user_management/api/tests/test_urls.py
@@ -65,3 +65,10 @@ class TestURLs(URLTestCase):
             url_name='user_management_api:verify_user',
             url_kwargs={'uidb64': uidb64, 'token': token},
         )
+
+    def test_resend_confirmation_email(self):
+        self.assert_url_matches_view(
+            view=views.ResendConfirmationEmail,
+            expected_url='/resend-confirmation-email',
+            url_name='user_management_api:resend_confirmation_email',
+        )

--- a/user_management/api/tests/test_urls.py
+++ b/user_management/api/tests/test_urls.py
@@ -55,3 +55,13 @@ class TestURLs(URLTestCase):
             view=views.UserList,
             expected_url='/users',
             url_name='user_management_api:user_list')
+
+    def test_verify_email(self):
+        uidb64 = '123'
+        token = 'a-token'
+        self.assert_url_matches_view(
+            view=views.VerifyAccountView,
+            expected_url='/verify_email/{}/{}'.format(uidb64, token),
+            url_name='user_management_api:verify_user',
+            url_kwargs={'uidb64': uidb64, 'token': token},
+        )

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -842,6 +842,10 @@ class TestUserDetail(APIRequestTestCase):
 class ResendConfirmationEmailTest(APIRequestTestCase):
     view_class = views.ResendConfirmationEmail
 
+    def setUp(self):
+        """Avoid view to be throttled for tests."""
+        self.view_class.throttle_scope = None
+
     def test_post(self):
         """Assert user can request a new confirmation email."""
         user = UserFactory.create()

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -837,3 +837,30 @@ class TestUserDetail(APIRequestTestCase):
 
         user = User.objects.get()
         self.assertEqual(self.user, user)
+
+
+class ResendConfirmationEmailTest(APIRequestTestCase):
+    view_class = views.ResendConfirmationEmail
+
+    def test_post(self):
+        user = UserFactory.create()
+        data = {'email': user.email}
+        request = self.create_request('post', auth=False, data=data)
+        view = self.view_class.as_view()
+        response = view(request)
+        self.assertEqual(
+            response.status_code,
+            status.HTTP_204_NO_CONTENT,
+            msg=response.data,
+        )
+
+    def test_send_email(self):
+        user = UserFactory.create()
+        data = {'email': user.email}
+        request = self.create_request('post', auth=False, data=data)
+        view = self.view_class.as_view()
+        view(request)
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+        self.assertIn(user.email, email.to)

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -15,6 +15,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from user_management.api import models, views
+from user_management.api.tests.test_throttling import THROTTLE_RATE_PATH
 from user_management.models.tests.factories import AuthTokenFactory, UserFactory
 from user_management.models.tests.models import BasicUser
 from user_management.models.tests.utils import APIRequestTestCase
@@ -839,6 +840,7 @@ class TestUserDetail(APIRequestTestCase):
         self.assertEqual(self.user, user)
 
 
+@patch(THROTTLE_RATE_PATH, new={'confirmations': '4/minute'})
 class ResendConfirmationEmailTest(APIRequestTestCase):
     view_class = views.ResendConfirmationEmail
 

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -842,6 +842,7 @@ class TestUserDetail(APIRequestTestCase):
 
 @patch(THROTTLE_RATE_PATH, new={'confirmations': '4/minute'})
 class ResendConfirmationEmailTest(APIRequestTestCase):
+    """Assert `ResendConfirmationEmail` behaves properly."""
     view_class = views.ResendConfirmationEmail
 
     def test_post(self):

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -842,10 +842,6 @@ class TestUserDetail(APIRequestTestCase):
 class ResendConfirmationEmailTest(APIRequestTestCase):
     view_class = views.ResendConfirmationEmail
 
-    def setUp(self):
-        """Avoid view to be throttled for tests."""
-        self.view_class.throttle_scope = None
-
     def test_post(self):
         """Assert user can request a new confirmation email."""
         user = UserFactory.create()

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -886,4 +886,10 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
 
         self.assertEqual(len(mail.outbox), 1)
         email = mail.outbox[0]
+
         self.assertIn(user.email, email.to)
+        expected = 'http://example.com/#/register/verify/'
+        self.assertIn(expected, email.body)
+
+        expected = 'example.com account validate'
+        self.assertEqual(email.subject, expected)

--- a/user_management/api/throttling.py
+++ b/user_management/api/throttling.py
@@ -45,8 +45,10 @@ class UsernameLoginRateThrottle(LoginRateThrottle):
 
 
 class PasswordResetRateThrottle(ScopedRateThrottleBase):
+    """Set `default_rate` for scoped rate POST requests on password reset."""
     default_rate = '3/hour'
 
 
 class ResendConfirmationEmailRateThrottle(ScopedRateThrottleBase):
+    """Set `default_rate` for scoped rate POST requests on `ResendConfirmationEmail`."""
     default_rate = '3/hour'

--- a/user_management/api/throttling.py
+++ b/user_management/api/throttling.py
@@ -20,10 +20,12 @@ class PostRequestThrottleMixin(object):
         return super(PostRequestThrottleMixin, self).allow_request(request, view)
 
 
-class LoginRateThrottle(
-        DefaultRateMixin,
-        PostRequestThrottleMixin,
-        ScopedRateThrottle):
+class ScopedRateThrottleBase(
+        DefaultRateMixin, PostRequestThrottleMixin, ScopedRateThrottle):
+    """Base class to define a scoped rate throttle on POST request."""
+
+
+class LoginRateThrottle(ScopedRateThrottleBase):
     default_rate = '10/hour'
 
 
@@ -42,15 +44,9 @@ class UsernameLoginRateThrottle(LoginRateThrottle):
         }
 
 
-class PasswordResetRateThrottle(
-        DefaultRateMixin,
-        PostRequestThrottleMixin,
-        ScopedRateThrottle):
+class PasswordResetRateThrottle(ScopedRateThrottleBase):
     default_rate = '3/hour'
 
 
-class ResendConfirmationEmailRateThrottle(
-        DefaultRateMixin,
-        PostRequestThrottleMixin,
-        ScopedRateThrottle):
+class ResendConfirmationEmailRateThrottle(ScopedRateThrottleBase):
     default_rate = '3/hour'

--- a/user_management/api/throttling.py
+++ b/user_management/api/throttling.py
@@ -47,3 +47,10 @@ class PasswordResetRateThrottle(
         PostRequestThrottleMixin,
         ScopedRateThrottle):
     default_rate = '3/hour'
+
+
+class ResendConfirmationEmailRateThrottle(
+        DefaultRateMixin,
+        PostRequestThrottleMixin,
+        ScopedRateThrottle):
+    default_rate = '3/hour'

--- a/user_management/api/urls/register.py
+++ b/user_management/api/urls/register.py
@@ -10,4 +10,9 @@ urlpatterns = patterns(
         view=views.UserRegister.as_view(),
         name='register',
     ),
+    url(
+        regex=r'^resend-confirmation-email/?$',
+        view=views.ResendConfirmationEmail.as_view(),
+        name='resend_confirmation_email',
+    ),
 )

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -225,6 +225,8 @@ class ResendConfirmationEmail(generics.GenericAPIView):
     """Resend a confirmation email."""
     permission_classes = [permissions.IsNotAuthenticated]
     serializer_class = serializers.ResendConfirmationEmailSerializer
+    throttle_classes = [throttling.ResendConfirmationEmailRateThrottle]
+    throttle_scope = 'confirmations'
 
     def post(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.DATA)

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -229,6 +229,7 @@ class ResendConfirmationEmail(generics.GenericAPIView):
     throttle_scope = 'confirmations'
 
     def post(self, request, *args, **kwargs):
+        """Validate `email` and send a request to confirm it."""
         serializer = self.serializer_class(data=request.DATA)
 
         if not serializer.is_valid():

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -221,8 +221,20 @@ class UserDetail(generics.RetrieveUpdateDestroyAPIView):
     serializer_class = serializers.UserSerializer
 
 
-class ResendConfirmationEmail(PasswordResetEmail):
+class ResendConfirmationEmail(generics.GenericAPIView):
     """Resend a confirmation email."""
+    permission_classes = [permissions.IsNotAuthenticated]
+    serializer_class = serializers.ResendConfirmationEmailSerializer
 
-    def send_email(self, user):
-        user.send_validation_email()
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.DATA)
+
+        if not serializer.is_valid():
+            return response.Response(
+                serializer.errors,
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        serializer.user.send_validation_email()
+        msg = _('Email confirmation sent.')
+        return response.Response(msg, status=status.HTTP_204_NO_CONTENT)

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -219,3 +219,10 @@ class UserDetail(generics.RetrieveUpdateDestroyAPIView):
     model = User
     permission_classes = (IsAuthenticated, permissions.IsAdminOrReadOnly)
     serializer_class = serializers.UserSerializer
+
+
+class ResendConfirmationEmail(PasswordResetEmail):
+    """Resend a confirmation email."""
+
+    def send_email(self, user):
+        user.send_validation_email()


### PR DESCRIPTION
If the link to confirm a registration hasn't been clicked after x days it
becomes invalid.

- [x] If the email address does not exist then it should raise a validation error
(about the email field).
- [x] If the user is already validated / active then it should raise a validation
error (about the email field).
- [x] If the user is is not validated / active then the system should generate and
send a new email validation link.
- [x] Add a rate limit to the view like the password reset.