### PR TITLE
Return another HTTP code when the token and uidb64 are not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v4.2.0 (Upcoming)
+
+* Return `PermissionDenied` `403` instead of `404` `NotFound` for not valid
+`uidb64` and `token`
+
 ## v4.1.0
 
 * Add `ResendConfirmationEmail` view.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v4.2.0 (Upcoming)
 
-* Return `PermissionDenied` `403` instead of `404` `NotFound` for not valid
+* Return `AuthenticationFailed` `401` instead of `404` `NotFound` for not valid
 `uidb64` and `token`
 
 ## v4.1.0

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -381,7 +381,7 @@ class TestPasswordReset(APIRequestTestCase):
         request = self.create_request('put', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_put_invalid_token(self):
         user = UserFactory.create()
@@ -402,7 +402,7 @@ class TestPasswordReset(APIRequestTestCase):
         view_name = 'user_management_api:password_reset_confirm'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 
@@ -551,7 +551,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_post_invalid_token(self):
         user = UserFactory.create()
@@ -599,7 +599,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         view_name = 'user_management_api:verify_user'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -381,7 +381,7 @@ class TestPasswordReset(APIRequestTestCase):
         request = self.create_request('put', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_put_invalid_token(self):
         user = UserFactory.create()
@@ -392,7 +392,7 @@ class TestPasswordReset(APIRequestTestCase):
         request = self.create_request('put', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_full_stack_wrong_url(self):
         user = UserFactory.create()
@@ -402,7 +402,7 @@ class TestPasswordReset(APIRequestTestCase):
         view_name = 'user_management_api:password_reset_confirm'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 
@@ -551,7 +551,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_invalid_token(self):
         user = UserFactory.create()
@@ -562,7 +562,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_post_verified_email(self):
         user = UserFactory.create(email_verification_required=False)
@@ -599,7 +599,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         view_name = 'user_management_api:verify_user'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -9,6 +9,7 @@ from incuna_mail import send
 from rest_framework import generics, renderers, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from . import models, permissions, serializers, throttling
@@ -151,7 +152,8 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            raise Http404()
+            msg = _('Invalid or expired token.')
+            raise PermissionDenied(detail=msg)
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -9,7 +9,7 @@ from incuna_mail import send
 from rest_framework import generics, renderers, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.exceptions import PermissionDenied
+from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from . import models, permissions, serializers, throttling
@@ -152,12 +152,12 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            msg = _('Invalid or expired token.')
-            raise PermissionDenied(detail=msg)
+            raise AuthenticationFailed()
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):
-            raise Http404()
+            msg = _('Invalid or expired token.')
+            raise AuthenticationFailed(detail=msg)
 
         return super(OneTimeUseAPIMixin, self).initial(
             request,

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -145,6 +145,8 @@ class PasswordResetEmail(generics.GenericAPIView):
 
 
 class OneTimeUseAPIMixin(object):
+    message = _('Invalid or expired token.')
+
     def initial(self, request, *args, **kwargs):
         uidb64 = kwargs['uidb64']
         uid = urlsafe_base64_decode(force_text(uidb64))
@@ -152,12 +154,11 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            raise AuthenticationFailed()
+            raise AuthenticationFailed(detail=self.message)
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):
-            msg = _('Invalid or expired token.')
-            raise AuthenticationFailed(detail=msg)
+            raise AuthenticationFailed(detail=self.message)
 
         return super(OneTimeUseAPIMixin, self).initial(
             request,


### PR DESCRIPTION
When submitting an expired or a non valid code to `VerifyAccountView` and `PasswordReset` we are currently returning a [`404`](https://github.com/incuna/django-user-management/blob/bf6a967d038c037376fa19f34bf712155dcca11a/user_management/api/views.py#L154). Returning another code would help to determine that the uidb64/token is not valid anymore.