### PR TITLE
Return HTTP Bad Request 400 code when the token and uidb64 are not valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v4.2.1 (Upcoming)
+
+* Return 400 instead of 401 when `uidb64` or `token` is expired or not valid.
+
 ## v4.2.0
 
 * Return `AuthenticationFailed` `401` instead of `404` `NotFound` for not valid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v4.2.1 (Upcoming)
+## v5.0.0 (Upcoming)
 
 * Return 400 instead of 401 when `uidb64` or `token` is expired or not valid.
 

--- a/user_management/api/exceptions.py
+++ b/user_management/api/exceptions.py
@@ -1,0 +1,9 @@
+from django.utils.translation import ugettext_lazy as _
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class InvalidExpiredToken(APIException):
+    """Exception to confirm an account."""
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = _('Invalid or expired token.')

--- a/user_management/api/tests/test_exceptions.py
+++ b/user_management/api/tests/test_exceptions.py
@@ -1,0 +1,14 @@
+from django.test import TestCase
+from rest_framework.status import HTTP_400_BAD_REQUEST
+
+from ..exceptions import InvalidExpiredToken
+
+
+class InvalidExpiredTokenTest(TestCase):
+    """Assert `InvalidExpiredToken` behaves as expected."""
+    def test_raise(self):
+        """Assert `InvalidExpiredToken` can be raised."""
+        with self.assertRaises(InvalidExpiredToken) as e:
+            raise InvalidExpiredToken
+        self.assertEqual(e.exception.status_code, HTTP_400_BAD_REQUEST)
+        self.assertEqual(str(e.exception.detail), 'Invalid or expired token.')

--- a/user_management/api/tests/test_exceptions.py
+++ b/user_management/api/tests/test_exceptions.py
@@ -11,4 +11,5 @@ class InvalidExpiredTokenTest(TestCase):
         with self.assertRaises(InvalidExpiredToken) as e:
             raise InvalidExpiredToken
         self.assertEqual(e.exception.status_code, HTTP_400_BAD_REQUEST)
-        self.assertEqual(str(e.exception.detail), 'Invalid or expired token.')
+        message = e.exception.detail.format()
+        self.assertEqual(message, 'Invalid or expired token.')

--- a/user_management/api/tests/test_exceptions.py
+++ b/user_management/api/tests/test_exceptions.py
@@ -8,8 +8,8 @@ class InvalidExpiredTokenTest(TestCase):
     """Assert `InvalidExpiredToken` behaves as expected."""
     def test_raise(self):
         """Assert `InvalidExpiredToken` can be raised."""
-        with self.assertRaises(InvalidExpiredToken) as e:
+        with self.assertRaises(InvalidExpiredToken) as error:
             raise InvalidExpiredToken
-        self.assertEqual(e.exception.status_code, HTTP_400_BAD_REQUEST)
-        message = e.exception.detail.format()
+        self.assertEqual(error.exception.status_code, HTTP_400_BAD_REQUEST)
+        message = error.exception.detail.format()
         self.assertEqual(message, 'Invalid or expired token.')

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -381,7 +381,7 @@ class TestPasswordReset(APIRequestTestCase):
         request = self.create_request('put', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_put_invalid_token(self):
         user = UserFactory.create()
@@ -392,7 +392,7 @@ class TestPasswordReset(APIRequestTestCase):
         request = self.create_request('put', auth=False)
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_full_stack_wrong_url(self):
         user = UserFactory.create()
@@ -402,7 +402,7 @@ class TestPasswordReset(APIRequestTestCase):
         view_name = 'user_management_api:password_reset_confirm'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.put(url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 
@@ -551,7 +551,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, uidb64=invalid_uid)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_invalid_token(self):
         user = UserFactory.create()
@@ -562,7 +562,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, uidb64=uid, token=token)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_verified_email(self):
         user = UserFactory.create(email_verification_required=False)
@@ -599,7 +599,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         view_name = 'user_management_api:verify_user'
         url = reverse(view_name, kwargs={'uidb64': uid, 'token': token})
         response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
         self.assertTrue(hasattr(response, 'accepted_renderer'))
 

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -8,10 +8,9 @@ from incuna_mail import send
 from rest_framework import generics, renderers, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.exceptions import ParseError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
-from . import models, permissions, serializers, throttling
+from . import exceptions, models, permissions, serializers, throttling
 
 
 User = get_user_model()
@@ -153,11 +152,11 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            raise ParseError(detail=self.message)
+            raise exceptions.InvalidExpiredToken(detail=self.message)
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):
-            raise ParseError(detail=self.message)
+            raise exceptions.InvalidExpiredToken(detail=self.message)
 
         return super(OneTimeUseAPIMixin, self).initial(
             request,

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -143,8 +143,6 @@ class PasswordResetEmail(generics.GenericAPIView):
 
 
 class OneTimeUseAPIMixin(object):
-    message = _('Invalid or expired token.')
-
     def initial(self, request, *args, **kwargs):
         uidb64 = kwargs['uidb64']
         uid = urlsafe_base64_decode(force_text(uidb64))
@@ -152,11 +150,11 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            raise exceptions.InvalidExpiredToken(detail=self.message)
+            raise exceptions.InvalidExpiredToken()
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):
-            raise exceptions.InvalidExpiredToken(detail=self.message)
+            raise exceptions.InvalidExpiredToken()
 
         return super(OneTimeUseAPIMixin, self).initial(
             request,

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -1,7 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
-from django.http import Http404
 from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
@@ -9,7 +8,7 @@ from incuna_mail import send
 from rest_framework import generics, renderers, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
-from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.exceptions import ParseError
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from . import models, permissions, serializers, throttling
@@ -154,11 +153,11 @@ class OneTimeUseAPIMixin(object):
         try:
             self.user = User.objects.get(pk=uid)
         except User.DoesNotExist:
-            raise AuthenticationFailed(detail=self.message)
+            raise ParseError(detail=self.message)
 
         token = kwargs['token']
         if not default_token_generator.check_token(self.user, token):
-            raise AuthenticationFailed(detail=self.message)
+            raise ParseError(detail=self.message)
 
         return super(OneTimeUseAPIMixin, self).initial(
             request,


### PR DESCRIPTION
Related to #98 where a 401 was implemented