### PR TITLE
User can log in to unverified account

### DIFF
--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -1,9 +1,6 @@
-from django.contrib.auth import authenticate, get_user_model
+from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 from rest_framework import serializers
-from rest_framework.authtoken.serializers import (
-    AuthTokenSerializer as DRFAuthTokenSerializer
-)
 
 from user_management.utils.validators import validate_password_strength
 
@@ -31,25 +28,6 @@ class EmailSerializerBase(serializers.Serializer):
 
     class Meta:
         fields = ['email']
-
-
-class AuthTokenSerializer(DRFAuthTokenSerializer):
-    """
-    Fix DRF's error messages (which ain't very helpful).
-
-    Also, end the indentation nonsense.
-    """
-    def validate(self, attrs):
-        username = attrs.get('username')
-        password = attrs.get('password')
-
-        user = authenticate(username=username, password=password)
-        if not user:
-            msg = _('Unable to log in with provided credentials.')
-            raise serializers.ValidationError(msg)
-
-        attrs['user'] = user
-        return attrs
 
 
 class RegistrationSerializer(ValidateEmailMixin, serializers.ModelSerializer):

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -29,32 +29,30 @@ class GetAuthTokenTest(APIRequestTestCase):
     model = models.AuthToken
     view_class = views.GetAuthToken
 
+    def setUp(self):
+        self.username = 'Test@example.com'
+        self.password = 'myepicstrongpassword'
+        self.data = {'username': self.username, 'password': self.password}
+
     def tearDown(self):
         cache.clear()
 
     def test_post(self):
-        username = 'Test@example.com'
-        password = 'myepicstrongpassword'
-        UserFactory.create(email=username.lower(), password=password)
+        UserFactory.create(email=self.username, password=self.password)
 
-        data = {'username': username, 'password': password}
-        request = self.create_request('post', auth=False, data=data)
+        request = self.create_request('post', auth=False, data=self.data)
         view = self.view_class.as_view()
         response = view(request)
         self.assertEqual(
             response.status_code, status.HTTP_200_OK, msg=response.data)
 
         # Ensure user has a token now
-        token = self.model.objects.get(user__email=username.lower())
+        token = self.model.objects.get()
         self.assertEqual(response.data['token'], token.key)
 
     def test_post_non_existing_user(self):
         """Assert non existing raises an error."""
-        username = 'Test@example.com'
-        password = 'myepicstrongpassword'
-
-        data = {'username': username, 'password': password}
-        request = self.create_request('post', auth=False, data=data)
+        request = self.create_request('post', auth=False, data=self.data)
         view = self.view_class.as_view()
         response = view(request)
         self.assertEqual(
@@ -68,12 +66,9 @@ class GetAuthTokenTest(APIRequestTestCase):
 
     def test_post_user_not_confirmed(self):
         """Assert non active users can not log in."""
-        username = 'Test@example.com'
-        password = 'myepicstrongpassword'
-        UserFactory.create(email=username.lower(), password=password, is_active=False)
+        UserFactory.create(email=self.username, password=self.password, is_active=False)
 
-        data = {'username': username, 'password': password}
-        request = self.create_request('post', auth=False, data=data)
+        request = self.create_request('post', auth=False, data=self.data)
         view = self.view_class.as_view()
         response = view(request)
         self.assertEqual(

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -38,6 +38,7 @@ class GetAuthTokenTest(APIRequestTestCase):
         cache.clear()
 
     def test_post(self):
+        """Assert user can sign in"""
         UserFactory.create(email=self.username, password=self.password)
 
         request = self.create_request('post', auth=False, data=self.data)

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -5,7 +5,7 @@ from django.utils.encoding import force_bytes, force_text
 from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 from incuna_mail import send
-from rest_framework import generics, renderers, response, status, views
+from rest_framework import generics, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.permissions import AllowAny, IsAuthenticated
@@ -18,8 +18,6 @@ User = get_user_model()
 
 class GetAuthToken(ObtainAuthToken):
     model = models.AuthToken
-    renderer_classes = (renderers.JSONRenderer, renderers.BrowsableAPIRenderer)
-    serializer_class = serializers.AuthTokenSerializer
     throttle_classes = [
         throttling.UsernameLoginRateThrottle,
         throttling.LoginRateThrottle,


### PR DESCRIPTION
The server returns a token, but when using the token in a request it will return a `401`.