### PR TITLE
Correct `fields` on `UserChangeForm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v7.0.1 (Upcoming)
+
+* Fix `UserChangeForm` admin form to use `exclude` instead of `fields`.
+
 ## v7.0.0
 
 * Add `delete` to `ProfileDetail` view

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v7.0.1 (Upcoming)
 
-* Fix `UserChangeForm` admin form to use `exclude` instead of `fields`.
+* Fix `UserChangeForm` admin form `fields` to only include fields used in `UserAdmin.fieldsets`.
 
 ## v7.0.0
 

--- a/user_management/models/admin_forms.py
+++ b/user_management/models/admin_forms.py
@@ -69,7 +69,17 @@ class UserChangeForm(forms.ModelForm):
     password = ReadOnlyPasswordHashField()
 
     class Meta:
-        exclude = ()
+        fields = (
+            'email',
+            'groups',
+            'is_active',
+            'is_staff',
+            'is_superuser',
+            'last_login',
+            'name',
+            'password',
+            'user_permissions',
+        )
         model = User
 
     def clean_password(self):

--- a/user_management/models/admin_forms.py
+++ b/user_management/models/admin_forms.py
@@ -69,19 +69,7 @@ class UserChangeForm(forms.ModelForm):
     password = ReadOnlyPasswordHashField()
 
     class Meta:
-        fields = (
-            'avatar',
-            'email',
-            'email_verification_required',
-            'groups',
-            'is_active',
-            'is_staff',
-            'is_superuser',
-            'last_login',
-            'name',
-            'password',
-            'user_permissions',
-        )
+        exclude = ()
         model = User
 
     def clean_password(self):

--- a/user_management/models/tests/test_admin_forms.py
+++ b/user_management/models/tests/test_admin_forms.py
@@ -80,9 +80,7 @@ class UserChangeFormTest(Python2AssertMixin, TestCase):
         """Assert `fields`."""
         fields = self.form.base_fields.keys()
         expected = (
-            'avatar',
             'email',
-            'email_verification_required',
             'groups',
             'is_active',
             'is_staff',


### PR DESCRIPTION
* The `User` model may have an arbitrary combination of fields based on
  the mixins used, and any extra fields added by the project.