### PR TITLE
Add `incuna-pigeon` to send notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.0.0 (Upcoming)
+
+Use `incuna-pigeon` for notifications.
+
 ## v7.0.1
 
 * Fix `UserChangeForm` admin form `fields` to only include fields used in `UserAdmin.fieldsets`.

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ version = '7.0.1'
 install_requires = (
     'djangorestframework>=2.4.4,<3',
     'incuna_mail>=2.0.0,<4.0.0',
+    'incuna-pigeon>=0.1.0,<1.0.0',
 )
 
 extras_require = {

--- a/user_management/api/templates/user_management/account_validation_email.html
+++ b/user_management/api/templates/user_management/account_validation_email.html
@@ -4,7 +4,7 @@ register an account at {{ site.name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
-http://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
+{{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
 
 {% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/account_validation_email.html
+++ b/user_management/api/templates/user_management/account_validation_email.html
@@ -1,10 +1,12 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with name=site.name %}
 You are receiving this email because your email address has been used to
-register an account at {{ site.name }}.
+register an account at {{ name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
 {{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
 
-{% endautoescape %}
+{% blocktrans with name=site.name %}
+The {{ name }} team.
+{% endblocktrans %}{% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/account_validation_email.txt
+++ b/user_management/api/templates/user_management/account_validation_email.txt
@@ -4,7 +4,7 @@ register an account at {{ site.name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
-http://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
+https://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
 
 {% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/account_validation_email.txt
+++ b/user_management/api/templates/user_management/account_validation_email.txt
@@ -1,10 +1,12 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with name=site.name %}
 You are receiving this email because your email address has been used to
-register an account at {{ site.name }}.
+register an account at {{ name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
 {{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
 
-{% endautoescape %}
+{% blocktrans with name=site.name %}
+The {{ name }} team.
+{% endblocktrans %}{% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/account_validation_email.txt
+++ b/user_management/api/templates/user_management/account_validation_email.txt
@@ -4,7 +4,7 @@ register an account at {{ site.name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
-https://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
+{{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
 
 {% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/password_reset_email.html
+++ b/user_management/api/templates/user_management/password_reset_email.html
@@ -1,10 +1,10 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with site=site.name domain=site.domain %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with name=site.name %}
 You are receiving this email because you requested a password reset
 for your user account at {{ name }}.
 
 Please go to the following page and choose a new password:{% endblocktrans %}
-{{ protocol }}://{{ domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
-{% blocktrans %}
-The {{ site.name }} team.
+{{ protocol }}://{{ site.domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
+{% blocktrans with name=site.name %}
+The {{ name }} team.
 {% endblocktrans %}{% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/password_reset_email.html
+++ b/user_management/api/templates/user_management/password_reset_email.html
@@ -1,9 +1,9 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with site=site.name domain=site.domain %}
 You are receiving this email because you requested a password reset
-for your user account at {{ site.name }}.
+for your user account at {{ name }}.
 
 Please go to the following page and choose a new password:{% endblocktrans %}
-{{ protocol }}://{{ site.domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
 {% blocktrans %}
 The {{ site.name }} team.
 {% endblocktrans %}{% endautoescape %}

--- a/user_management/api/templates/user_management/password_reset_email.txt
+++ b/user_management/api/templates/user_management/password_reset_email.txt
@@ -1,0 +1,10 @@
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+You are receiving this email because you requested a password reset
+for your user account at {{ site.name }}.
+
+Please go to the following page and choose a new password:{% endblocktrans %}
+{{ protocol }}://{{ site.domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
+{% blocktrans %}
+The {{ site.name }} team.
+{% endblocktrans %}{% endautoescape %}
+{% endspaceless %}

--- a/user_management/api/templates/user_management/password_reset_email.txt
+++ b/user_management/api/templates/user_management/password_reset_email.txt
@@ -1,10 +1,10 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with site=site.name domain=site.domain %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with name=site.name %}
 You are receiving this email because you requested a password reset
 for your user account at {{ name }}.
 
 Please go to the following page and choose a new password:{% endblocktrans %}
-{{ protocol }}://{{ domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
-{% blocktrans %}
-The {{ site.name }} team.
+{{ protocol }}://{{ site.domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
+{% blocktrans with name=site.name %}
+The {{ name }} team.
 {% endblocktrans %}{% endautoescape %}
 {% endspaceless %}

--- a/user_management/api/templates/user_management/password_reset_email.txt
+++ b/user_management/api/templates/user_management/password_reset_email.txt
@@ -1,9 +1,9 @@
-{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans %}
+{% spaceless %}{% load i18n %}{% autoescape off %}{% blocktrans with site=site.name domain=site.domain %}
 You are receiving this email because you requested a password reset
-for your user account at {{ site.name }}.
+for your user account at {{ name }}.
 
 Please go to the following page and choose a new password:{% endblocktrans %}
-{{ protocol }}://{{ site.domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
+{{ protocol }}://{{ domain }}{% url 'user_management_api:password_reset_confirm' uidb64=uid token=token %}
 {% blocktrans %}
 The {{ site.name }} team.
 {% endblocktrans %}{% endautoescape %}

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -4,6 +4,7 @@ import re
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import check_password
 from django.contrib.auth.tokens import default_token_generator
+from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
@@ -23,6 +24,8 @@ from user_management.models.tests.utils import APIRequestTestCase
 
 User = get_user_model()
 TEST_SERVER = 'http://testserver'
+SEND_METHOD = 'user_management.utils.notifications.incuna_mail.send'
+EMAIL_CONTEXT = 'user_management.models.mixins.EmailVerifyUserMethodsMixin.email_context'
 
 
 class GetAuthTokenTest(APIRequestTestCase):
@@ -186,7 +189,7 @@ class TestRegisterView(APIRequestTestCase):
         email = mail.outbox[0]
         verify_url_regex = re.compile(
             r'''
-                http://example\.com/\#/register/verify/
+                https://example\.com/\#/register/verify/
                 [0-9A-Za-z_\-]+/  # uid
                 [0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20}/  # token
             ''',
@@ -266,6 +269,8 @@ class TestPasswordResetEmail(APIRequestTestCase):
     def test_existent_email(self):
         email = 'exists@example.com'
         user = UserFactory.create(email=email)
+        context = {}
+        site = Site.objects.get_current()
 
         request = self.create_request(
             'post',
@@ -273,11 +278,20 @@ class TestPasswordResetEmail(APIRequestTestCase):
             auth=False,
         )
         view = self.view_class.as_view()
-        with patch.object(self.view_class, 'send_email') as send_email:
-            response = view(request)
+        with patch(EMAIL_CONTEXT) as get_context:
+            get_context.return_value = context
+            with patch(SEND_METHOD) as send_email:
+                response = view(request)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
-        send_email.assert_called_once_with(user)
+        expected = {
+            'to': user.email,
+            'template_name': 'user_management/password_reset_email.txt',
+            'html_template_name': 'user_management/password_reset_email.html',
+            'subject': '{} password reset'.format(site.domain),
+            'context': context,
+        }
+        send_email.assert_called_once_with(**expected)
 
     def test_authenticated(self):
         request = self.create_request('post', auth=True)
@@ -295,7 +309,7 @@ class TestPasswordResetEmail(APIRequestTestCase):
             auth=False,
         )
         view = self.view_class.as_view()
-        with patch.object(self.view_class, 'send_email') as send_email:
+        with patch(SEND_METHOD) as send_email:
             response = view(request)
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
@@ -307,15 +321,18 @@ class TestPasswordResetEmail(APIRequestTestCase):
         response = view(request)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-    def test_send_email(self):
-        email = 'test@example.com'
-        user = UserFactory.create(
-            email=email,
-            # Don't send the verification email
-            email_verification_required=False,
-        )
+    def test_email_content(self):
+        """Assert email content is output correctly."""
+        email = 'exists@example.com'
+        user = UserFactory.create(email=email)
 
-        self.view_class().send_email(user)
+        request = self.create_request(
+            'post',
+            data={'email': email},
+            auth=False,
+        )
+        view = self.view_class.as_view()
+        view(request)
 
         self.assertEqual(len(mail.outbox), 1)
 
@@ -955,7 +972,7 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
         email = mail.outbox[0]
 
         self.assertIn(user.email, email.to)
-        expected = 'http://example.com/#/register/verify/'
+        expected = 'https://example.com/#/register/verify/'
         self.assertIn(expected, email.body)
 
         expected = 'example.com account validate'

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -25,7 +25,7 @@ from user_management.models.tests.utils import APIRequestTestCase
 User = get_user_model()
 TEST_SERVER = 'http://testserver'
 SEND_METHOD = 'user_management.utils.notifications.incuna_mail.send'
-EMAIL_CONTEXT = 'user_management.models.mixins.EmailVerifyUserMethodsMixin.email_context'
+EMAIL_CONTEXT = 'user_management.utils.notifications.email_context'
 
 
 class GetAuthTokenTest(APIRequestTestCase):

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -1,10 +1,8 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
-from django.contrib.sites.models import Site
-from django.utils.encoding import force_bytes, force_text
-from django.utils.http import urlsafe_base64_decode, urlsafe_base64_encode
+from django.utils.encoding import force_text
+from django.utils.http import urlsafe_base64_decode
 from django.utils.translation import ugettext_lazy as _
-from incuna_mail import send
 from rest_framework import generics, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
@@ -103,14 +101,6 @@ class PasswordResetEmail(generics.GenericAPIView):
     throttle_classes = [throttling.PasswordResetRateThrottle]
     throttle_scope = 'passwords'
 
-    def email_context(self, site, user):
-        return {
-            'protocol': 'https',
-            'site': site,
-            'token': default_token_generator.make_token(user),
-            'uid': urlsafe_base64_encode(force_bytes(user.pk)),
-        }
-
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.DATA)
         if not serializer.is_valid():
@@ -125,19 +115,10 @@ class PasswordResetEmail(generics.GenericAPIView):
         except User.DoesNotExist:
             pass
         else:
-            self.send_email(user)
+            user.send_password_reset()
 
         msg = _('Password reset request successful. Please check your email.')
         return response.Response(msg, status=status.HTTP_204_NO_CONTENT)
-
-    def send_email(self, user):
-        site = Site.objects.get_current()
-        send(
-            to=[user.email],
-            template_name=self.template_name,
-            subject=_('{domain} password reset').format(domain=site.domain),
-            context=self.email_context(site, user),
-        )
 
 
 class OneTimeUseAPIMixin(object):

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -6,10 +6,7 @@ from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext_lazy as _
 
-from user_management.utils.notifications import (
-    PasswordResetNotification,
-    ValidationNotification,
-)
+from user_management.utils import notifications
 
 
 class UserManager(BaseUserManager):
@@ -136,8 +133,8 @@ class EmailVerifyUserMethodsMixin:
     `password_reset_notification` and `validation_notification` can be overriden to
     provide custom settings to send emails.
     """
-    password_reset_notification = PasswordResetNotification
-    validation_notification = ValidationNotification
+    password_reset_notification = notifications.PasswordResetNotification
+    validation_notification = notifications.ValidationNotification
 
     def send_validation_email(self):
         """Send a validation email to the user's email address."""
@@ -145,20 +142,12 @@ class EmailVerifyUserMethodsMixin:
             raise ValueError(_('Cannot validate already active user.'))
 
         site = Site.objects.get_current()
-        notification = self.validation_notification(
-            user=self,
-            site=site,
-        )
-        notification.notify()
+        self.validation_notification(user=self, site=site).notify()
 
     def send_password_reset(self):
         """Send a password reset to the user's email address."""
         site = Site.objects.get_current()
-        notification = self.password_reset_notification(
-            user=self,
-            site=site,
-        )
-        notification.notify()
+        self.password_reset_notification(user=self, site=site).notify()
 
 
 class EmailVerifyUserMixin(EmailVerifyUserMethodsMixin, models.Model):

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -7,7 +7,8 @@ from django.utils import timezone
 from django.utils.encoding import force_bytes, python_2_unicode_compatible
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
-from incuna_mail import send
+
+from user_management.utils.notifications import Notification
 
 
 class UserManager(BaseUserManager):
@@ -128,56 +129,44 @@ class VerifyEmailManager(UserManager):
 
 
 class EmailVerifyUserMethodsMixin:
-    EMAIL_SUBJECT = '{domain} account validate'
-    TEXT_EMAIL_TEMPLATE = 'user_management/account_validation_email.txt'
-    HTML_EMAIL_TEMPLATE = 'user_management/account_validation_email.html'
-
     def email_context(self, site):
         return {
+            'protocol': 'https',
             'uid': urlsafe_base64_encode(force_bytes(self.pk)),
             'token': default_token_generator.make_token(self),
             'site': site,
         }
 
-    def email_kwargs(self, context, domain):
-        """Prepare the kwargs to be passed to incuna_mail.send"""
-        return {
-            'to': [self.email],
-            'template_name': self.TEXT_EMAIL_TEMPLATE,
-            'html_template_name': self.HTML_EMAIL_TEMPLATE,
-            'subject': self.get_email_subject(domain),
-            'context': context,
-        }
-
-    def get_email_subject(self, domain):
-        return _(self.EMAIL_SUBJECT).format(domain=domain)
-
     def send_validation_email(self):
-        """
-        Send a validation email to the user's email address.
-
-        The email subject can be customised by overriding
-        VerifyEmailMixin.EMAIL_SUBJECT or VerifyEmailMixin.get_email_subject.
-        To include your site's domain in the subject, include {domain} in
-        VerifyEmailMixin.EMAIL_SUBJECT.
-
-        By default send_validation_email sends a multipart email using
-        VerifyEmailMixin.TEXT_EMAIL_TEMPLATE and
-        VerifyEmailMixin.HTML_EMAIL_TEMPLATE. To send a text-only email
-        set VerifyEmailMixin.HTML_EMAIL_TEMPLATE to None.
-
-        You can also customise the context available in the email templates
-        by extending VerifyEmailMixin.email_context.
-
-        If you want more control over the sending of the email you can
-        extend VerifyEmailMixin.email_kwargs.
-        """
+        """Send a validation email to the user's email address."""
         if not self.email_verification_required:
             raise ValueError(_('Cannot validate already active user.'))
 
         site = Site.objects.get_current()
-        context = self.email_context(site)
-        send(**self.email_kwargs(context, site.domain))
+        email_subject = _('{domain} account validate'.format(domain=site.domain))
+
+        notification = Notification(
+            user=self,
+            text_email_template='user_management/account_validation_email.txt',
+            html_email_template='user_management/account_validation_email.html',
+            email_subject=email_subject,
+            context=self.email_context(site),
+        )
+        notification.notify()
+
+    def send_password_reset(self):
+        """Send a password reset to the user's email address."""
+        site = Site.objects.get_current()
+        email_subject = _('{domain} password reset'.format(domain=site.domain))
+
+        notification = Notification(
+            user=self,
+            text_email_template='user_management/password_reset_email.txt',
+            html_email_template='user_management/password_reset_email.html',
+            email_subject=email_subject,
+            context=self.email_context(site),
+        )
+        notification.notify()
 
 
 class EmailVerifyUserMixin(EmailVerifyUserMethodsMixin, models.Model):

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -130,7 +130,8 @@ class VerifyEmailManager(UserManager):
 
 
 class EmailVerifyUserMethodsMixin:
-    """Define how validation and password reset emails are sent.
+    """
+    Define how validation and password reset emails are sent.
 
     `password_reset_notification` and `validation_notification` can be overriden to
     provide custom settings to send emails.

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -1,9 +1,11 @@
 from django.contrib.auth.models import BaseUserManager
+from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
 from django.core import checks
 from django.db import models
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
+from django.utils.encoding import force_bytes, python_2_unicode_compatible
+from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 
 from user_management.utils import notifications
@@ -135,6 +137,14 @@ class EmailVerifyUserMethodsMixin:
     """
     password_reset_notification = notifications.PasswordResetNotification
     validation_notification = notifications.ValidationNotification
+
+    def generate_token(self):
+        """Generate user token for account validation."""
+        return default_token_generator.make_token(self)
+
+    def generate_uid(self):
+        """Generate user uid for account validation."""
+        return urlsafe_base64_encode(force_bytes(self.pk))
 
     def send_validation_email(self):
         """Send a validation email to the user's email address."""

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -8,7 +8,10 @@ from django.utils.encoding import force_bytes, python_2_unicode_compatible
 from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 
-from user_management.utils.notifications import Notification
+from user_management.utils.notifications import (
+    PasswordResetNotification,
+    ValidationNotification,
+)
 
 
 class UserManager(BaseUserManager):
@@ -145,10 +148,8 @@ class EmailVerifyUserMethodsMixin:
         site = Site.objects.get_current()
         email_subject = _('{domain} account validate'.format(domain=site.domain))
 
-        notification = Notification(
+        notification = ValidationNotification(
             user=self,
-            text_email_template='user_management/account_validation_email.txt',
-            html_email_template='user_management/account_validation_email.html',
             email_subject=email_subject,
             context=self.email_context(site),
         )
@@ -159,10 +160,8 @@ class EmailVerifyUserMethodsMixin:
         site = Site.objects.get_current()
         email_subject = _('{domain} password reset'.format(domain=site.domain))
 
-        notification = Notification(
+        notification = PasswordResetNotification(
             user=self,
-            text_email_template='user_management/password_reset_email.txt',
-            html_email_template='user_management/password_reset_email.html',
             email_subject=email_subject,
             context=self.email_context(site),
         )

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -132,6 +132,14 @@ class VerifyEmailManager(UserManager):
 
 
 class EmailVerifyUserMethodsMixin:
+    """Define how validation and password reset emails are sent.
+
+    `password_reset_notification` and `validation_notification` can be overriden to
+    provide custom settings to send emails.
+    """
+    password_reset_notification = PasswordResetNotification
+    validation_notification = ValidationNotification
+
     def email_context(self, site):
         return {
             'protocol': 'https',
@@ -148,7 +156,7 @@ class EmailVerifyUserMethodsMixin:
         site = Site.objects.get_current()
         email_subject = _('{domain} account validate'.format(domain=site.domain))
 
-        notification = ValidationNotification(
+        notification = self.validation_notification(
             user=self,
             email_subject=email_subject,
             context=self.email_context(site),
@@ -160,7 +168,7 @@ class EmailVerifyUserMethodsMixin:
         site = Site.objects.get_current()
         email_subject = _('{domain} password reset'.format(domain=site.domain))
 
-        notification = PasswordResetNotification(
+        notification = self.password_reset_notification(
             user=self,
             email_subject=email_subject,
             context=self.email_context(site),

--- a/user_management/models/tests/models.py
+++ b/user_management/models/tests/models.py
@@ -22,7 +22,7 @@ class BasicUser(BasicUserFieldsMixin, AbstractBaseUser):
     pass
 
 
-class VerifyEmailUser(VerifyEmailMixin):
+class VerifyEmailUser(VerifyEmailMixin, AbstractBaseUser):
     pass
 
 

--- a/user_management/models/tests/models.py
+++ b/user_management/models/tests/models.py
@@ -2,6 +2,7 @@ from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin
 from django.db import models
 
 
+from .notifications import CustomPasswordResetNotification
 from ..mixins import (
     AvatarMixin,
     BasicUserFieldsMixin,
@@ -24,6 +25,11 @@ class BasicUser(BasicUserFieldsMixin, AbstractBaseUser):
 
 class VerifyEmailUser(VerifyEmailMixin, AbstractBaseUser):
     pass
+
+
+class CustomVerifyEmailUser(VerifyEmailMixin, AbstractBaseUser):
+    """Customise the notification class to send a password reset."""
+    password_reset_notification = CustomPasswordResetNotification
 
 
 class CustomBasicUserFieldsMixin(

--- a/user_management/models/tests/notifications.py
+++ b/user_management/models/tests/notifications.py
@@ -3,5 +3,5 @@ from user_management.utils.notifications import PasswordResetNotification
 
 class CustomPasswordResetNotification(PasswordResetNotification):
     """Test setting a custom notification to alter how we send the password reset."""
-    text_email_template = 'my_cystom_email.txt'
+    text_email_template = 'my_custom_email.txt'
     html_email_template = None

--- a/user_management/models/tests/notifications.py
+++ b/user_management/models/tests/notifications.py
@@ -1,0 +1,7 @@
+from user_management.utils.notifications import PasswordResetNotification
+
+
+class CustomPasswordResetNotification(PasswordResetNotification):
+    """Test setting a custom notification to alter how we send the password reset."""
+    text_email_template = 'my_cystom_email.txt'
+    html_email_template = None

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -302,7 +302,7 @@ class TestCustomPasswordResetNotification(TestCase):
 
         expected = {
             'to': user.email,
-            'template_name': 'my_cystom_email.txt',
+            'template_name': 'my_custom_email.txt',
             'html_template_name': None,
             'subject': '{} password reset'.format(site.domain),
             'context': context

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -279,3 +279,28 @@ class TestCustomNameUser(utils.APIRequestTestCase):
     def test_manager_check_invalid(self):
         errors = self.model.check()
         self.assertEqual(errors, [])
+
+
+class TestCustomPasswordResetNotification(TestCase):
+    """Assert we can customise the notification to send a password reset."""
+    model = models.CustomVerifyEmailUser
+
+    def test_send_password_reset_email(self):
+        """Assert `text_email_template` and `html_template_name` can be customised."""
+        context = {}
+        site = Site.objects.get_current()
+        user = self.model(email='email@email.email')
+
+        with patch.object(user, 'email_context') as get_context:
+            get_context.return_value = context
+            with patch(SEND_METHOD) as send:
+                user.send_password_reset()
+
+        expected = {
+            'to': user.email,
+            'template_name': 'my_cystom_email.txt',
+            'html_template_name': None,
+            'subject': '{} password reset'.format(site.domain),
+            'context': context
+        }
+        send.assert_called_once_with(**expected)

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -179,18 +179,21 @@ class TestVerifyEmailMixin(TestCase):
 
     def test_email_context(self):
         """Assert `email_context` returns the correct data."""
+        mocked_user = Mock()
+        mocked_site = Mock()
+
         class DummyNotification:
-            user = Mock()
-            site = Mock()
+            user = mocked_user
+            site = mocked_site
 
         notification = DummyNotification()
         context = email_context(notification)
 
         expected_context = {
             'protocol': 'https',
-            'uid': notification.user.generate_uid(),
-            'token': notification.user.generate_token(),
-            'site': notification.site,
+            'uid': mocked_user.generate_uid(),
+            'token': mocked_user.generate_token(),
+            'site': mocked_site,
         }
         self.assertEqual(context, expected_context)
 

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -1,0 +1,17 @@
+import incuna_mail
+from pigeon.notification import Notification as NotificationBase
+
+
+def email_handler(notification):
+    """Send a notification by email."""
+    incuna_mail.send(
+        to=notification.user.email,
+        subject=notification.email_subject,
+        template_name=notification.text_email_template,
+        html_template_name=notification.html_email_template,
+        context=notification.context,
+    )
+
+
+class Notification(NotificationBase):
+    handlers = (email_handler,)

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -1,5 +1,5 @@
 import incuna_mail
-from pigeon.notification import Notification as NotificationBase
+from pigeon.notification import Notification
 
 
 def email_handler(notification):
@@ -13,5 +13,18 @@ def email_handler(notification):
     )
 
 
-class Notification(NotificationBase):
+class NotificationBase(Notification):
+    """Base notification class defining an `email_handler`."""
     handlers = (email_handler,)
+
+
+class PasswordResetNotification(NotificationBase):
+    """`PasswordResetNotification` defining text and html email templates."""
+    text_email_template = 'user_management/password_reset_email.txt'
+    html_email_template = 'user_management/password_reset_email.html'
+
+
+class ValidationNotification(NotificationBase):
+    """`ValidationNotification` defining text and html email templates."""
+    text_email_template = 'user_management/account_validation_email.txt'
+    html_email_template = 'user_management/account_validation_email.html'

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -1,5 +1,18 @@
 import incuna_mail
+from django.contrib.auth.tokens import default_token_generator
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.utils.translation import ugettext_lazy as _
 from pigeon.notification import Notification
+
+
+def email_context(notification):
+    return {
+        'protocol': 'https',
+        'uid': urlsafe_base64_encode(force_bytes(notification.user.pk)),
+        'token': default_token_generator.make_token(notification.user),
+        'site': notification.site,
+    }
 
 
 def email_handler(notification):
@@ -9,22 +22,33 @@ def email_handler(notification):
         subject=notification.email_subject,
         template_name=notification.text_email_template,
         html_template_name=notification.html_email_template,
-        context=notification.context,
+        context=email_context(notification),
     )
 
 
-class NotificationBase(Notification):
-    """Base notification class defining an `email_handler`."""
-    handlers = (email_handler,)
+def password_reset_email_handler(notification):
+    """Password reset email handler."""
+    subject = _('{domain} password reset'.format(domain=notification.site.domain))
+    notification.email_subject = subject
+    email_handler(notification)
 
 
-class PasswordResetNotification(NotificationBase):
+def validation_email_handler(notification):
+    """Validation email handler."""
+    subject = _('{domain} account validate'.format(domain=notification.site.domain))
+    notification.email_subject = subject
+    email_handler(notification)
+
+
+class PasswordResetNotification(Notification):
     """`PasswordResetNotification` defines text and html email templates."""
+    handlers = (password_reset_email_handler,)
     text_email_template = 'user_management/password_reset_email.txt'
     html_email_template = 'user_management/password_reset_email.html'
 
 
-class ValidationNotification(NotificationBase):
+class ValidationNotification(Notification):
     """`ValidationNotification` defines text and html email templates."""
+    handlers = (validation_email_handler,)
     text_email_template = 'user_management/account_validation_email.txt'
     html_email_template = 'user_management/account_validation_email.html'

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -1,7 +1,4 @@
 import incuna_mail
-from django.contrib.auth.tokens import default_token_generator
-from django.utils.encoding import force_bytes
-from django.utils.http import urlsafe_base64_encode
 from django.utils.translation import ugettext_lazy as _
 from pigeon.notification import Notification
 
@@ -9,8 +6,8 @@ from pigeon.notification import Notification
 def email_context(notification):
     return {
         'protocol': 'https',
-        'uid': urlsafe_base64_encode(force_bytes(notification.user.pk)),
-        'token': default_token_generator.make_token(notification.user),
+        'uid': notification.user.generate_uid(),
+        'token': notification.user.generate_token(),
         'site': notification.site,
     }
 

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -19,12 +19,12 @@ class NotificationBase(Notification):
 
 
 class PasswordResetNotification(NotificationBase):
-    """`PasswordResetNotification` defining text and html email templates."""
+    """`PasswordResetNotification` defines text and html email templates."""
     text_email_template = 'user_management/password_reset_email.txt'
     html_email_template = 'user_management/password_reset_email.html'
 
 
 class ValidationNotification(NotificationBase):
-    """`ValidationNotification` defining text and html email templates."""
+    """`ValidationNotification` defines text and html email templates."""
     text_email_template = 'user_management/account_validation_email.txt'
     html_email_template = 'user_management/account_validation_email.html'


### PR DESCRIPTION
It looks like we have two different behaviors to send emails in `django-user-management`.
In [some](https://github.com/incuna/django-user-management/blob/be3ca0a4c63b0221e16659800c90831d69781978/user_management/api/views.py#L85) [places](https://github.com/incuna/django-user-management/blob/be3ca0a4c63b0221e16659800c90831d69781978/user_management/api/views.py#L238) we are sending html and text emails and in [`PasswordReset`](https://github.com/incuna/django-user-management/blob/be3ca0a4c63b0221e16659800c90831d69781978/user_management/api/views.py#L133-L140) we only send html emails.

Using `incuna-pigeon` would make sending emails behaving the same accross the project and would allow apps using `django-user-management` to customise handlers to send emails.

As this project is compatible with django1.6 and 1.7, I think it makes sense to define the notification handlers in settings.