### PR TITLE
Pin tox to 1.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: TOX_ENV=py34-djangopre
 install:
   - psql -c 'CREATE DATABASE user_management' -U postgres;
-  - pip install tox==1.9.0 coveralls
+  - pip install tox!=1.9.1 coveralls
 script:
   - tox -e $TOX_ENV
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - env: TOX_ENV=py34-djangopre
 install:
   - psql -c 'CREATE DATABASE user_management' -U postgres;
-  - pip install tox coveralls
+  - pip install tox==1.9.0 coveralls
 script:
   - tox -e $TOX_ENV
 after_success:


### PR DESCRIPTION
`tox` v1.9.1 raises an error when doing a pip install, it looks like
`deps` not installed are translated to `None` instead of being dropped from
the list.