### PR TITLE
Rename email_verification_required to email_verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v9.0.0 (Upcoming)
+
+* Replace `email_verification_required` flag with `email_verified` flag.
+** Note that `email_verified == not email_verification_required`.
+** A data migration will be necessary.
+
 ## v8.1.0
 
 * Add docstrings for views.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## v9.0.0 (Upcoming)
 
 * Replace `email_verification_required` flag with `email_verified` flag.
-** Note that `email_verified == not email_verification_required`.
-** A data migration will be necessary.
+ * Note that `email_verified == not email_verification_required`.
+ * A data migration will be necessary.
 
 ## v8.1.0
 

--- a/docs/mixins.md
+++ b/docs/mixins.md
@@ -9,7 +9,7 @@ mixin with a `name`, `email`, `date_joined`, `is_staff`, and `is_active`.
 
 `user_management.models.mixins.VerifyEmailMixin` extends ActiveUserMixin to
 provide functionality to verify the email. It includes an additional
-`email_verification_required` field.
+`email_verified` field.
 
 By default, users will be created with `is_active = False`. A verification email
 will be sent including a link to verify the email and activate the account.

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -161,7 +161,7 @@ class ResendConfirmationEmailSerializer(EmailSerializerBase):
             msg = _('A user with this email address does not exist.')
             raise serializers.ValidationError(msg)
 
-        if not self.user.email_verification_required:
+        if self.user.email_verified:
             msg = _('User email address is already verified.')
             raise serializers.ValidationError(msg)
         return attrs

--- a/user_management/api/tests/test_serializers.py
+++ b/user_management/api/tests/test_serializers.py
@@ -344,7 +344,7 @@ class ResendConfirmationEmailSerializerTest(TestCase):
 
     def test_user_already_validated(self):
         """Assert confirmation email is not send if user was already verified."""
-        user = UserFactory.create(email_verification_required=False)
+        user = UserFactory.create(email_verified=True)
         data = {'email': user.email}
         serializer = serializers.ResendConfirmationEmailSerializer(data=data)
         self.assertFalse(serializer.is_valid())

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -212,7 +212,7 @@ class TestRegisterView(APIRequestTestCase):
            new=BasicUser)
     def test_unauthenticated_user_post_no_verify_email(self):
         """
-        An email should not be sent if email_verification_required is False.
+        An email should not be sent if email_verified is True.
         """
         request = self.create_request('post', auth=False, data=self.data)
 
@@ -600,7 +600,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
-        self.assertFalse(updated_user.email_verification_required)
+        self.assertTrue(updated_user.email_verified)
         self.assertTrue(updated_user.is_active)
 
     def test_post_unauthenticated(self):
@@ -614,7 +614,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
-        self.assertFalse(updated_user.email_verification_required)
+        self.assertTrue(updated_user.email_verified)
         self.assertTrue(updated_user.is_active)
 
     def test_post_invalid_user(self):
@@ -638,7 +638,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_verified_email(self):
-        user = UserFactory.create(email_verification_required=False)
+        user = UserFactory.create(email_verified=True)
         token = default_token_generator.make_token(user)
         uid = urlsafe_base64_encode(force_bytes(user.pk))
 
@@ -659,10 +659,10 @@ class TestVerifyAccountView(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         updated_user = User.objects.get(pk=user.pk)
-        self.assertFalse(updated_user.email_verification_required)
+        self.assertTrue(updated_user.email_verified)
 
         logged_in_user = User.objects.get(pk=other_user.pk)
-        self.assertTrue(logged_in_user.email_verification_required)
+        self.assertFalse(logged_in_user.email_verified)
 
     def test_full_stack_wrong_url(self):
         user = UserFactory.create()
@@ -952,7 +952,7 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
 
     def test_post_email_already_verified(self):
         """Assert email already verified does not trigger another email."""
-        user = UserFactory.create(email_verification_required=False)
+        user = UserFactory.create(email_verified=True)
         data = {'email': user.email}
         request = self.create_request('post', auth=False, data=data)
         view = self.view_class.as_view()

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -71,8 +71,8 @@ class UserRegister(generics.CreateAPIView):
     """
     Register a new `User`.
 
-    An email to validate the new account is sent if `email_verification_required`
-    is set to `True`.
+    An email to validate the new account is sent if `email_verified`
+    is set to `False`.
     """
     serializer_class = serializers.RegistrationSerializer
     permission_classes = [permissions.IsNotAuthenticated]

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -94,7 +94,7 @@ class UserRegister(generics.CreateAPIView):
 
     def is_valid(self, serializer):
         serializer.save()
-        if serializer.object.email_verification_required:
+        if not serializer.object.email_verified:
             serializer.object.send_validation_email()
             ok_message = _(
                 'Your account has been created and an activation link sent ' +
@@ -213,10 +213,10 @@ class VerifyAccountView(OneTimeUseAPIMixin, views.APIView):
     ok_message = _('Your account has been verified.')
 
     def post(self, request, *args, **kwargs):
-        if not self.user.email_verification_required:
+        if self.user.email_verified:
             return response.Response(status=status.HTTP_403_FORBIDDEN)
 
-        self.user.email_verification_required = False
+        self.user.email_verified = True
         self.user.is_active = True
         self.user.save()
 

--- a/user_management/models/admin.py
+++ b/user_management/models/admin.py
@@ -44,7 +44,7 @@ class UserAdmin(BaseUserAdmin):
 
 
 class VerifyUserAdmin(UserAdmin):
-    readonly_fields = ('date_joined', 'email_verification_required')
+    readonly_fields = ('date_joined', 'email_verified')
 
     def get_fieldsets(self, request, obj=None):
         fieldsets = super(VerifyUserAdmin, self).get_fieldsets(request, obj)
@@ -62,6 +62,6 @@ class VerifyUserAdmin(UserAdmin):
             # removed and fieldsets will be correct so return it
             return fieldsets
 
-        fields[index] = ('is_active', 'email_verification_required')
+        fields[index] = ('is_active', 'email_verified')
         fieldsets_dict['Permissions']['fields'] = tuple(fields)
         return tuple(fieldsets_dict.items())

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -61,7 +61,7 @@ class EmailUserMixin(models.Model):
         unique=True,
         max_length=511,
     )
-    email_verification_required = False
+    email_verified = True
 
     objects = UserManager()
 
@@ -148,7 +148,7 @@ class EmailVerifyUserMethodsMixin:
 
     def send_validation_email(self):
         """Send a validation email to the user's email address."""
-        if not self.email_verification_required:
+        if self.email_verified:
             raise ValueError(_('Cannot validate already active user.'))
 
         site = Site.objects.get_current()
@@ -162,10 +162,10 @@ class EmailVerifyUserMethodsMixin:
 
 class EmailVerifyUserMixin(EmailVerifyUserMethodsMixin, models.Model):
     is_active = models.BooleanField(_('active'), default=False)
-    email_verification_required = models.BooleanField(
-        _('Email verification required?'),
-        default=True,
-        help_text=_('Indicates if the email address needs to be verified.'))
+    email_verified = models.BooleanField(
+        _('Email verified?'),
+        default=False,
+        help_text=_('Indicates if the email address has been verified.'))
 
     objects = VerifyEmailManager()
 

--- a/user_management/models/tests/test_admin.py
+++ b/user_management/models/tests/test_admin.py
@@ -30,7 +30,7 @@ class VerifyUserAdminTest(TestCase):
             ('Personal info', {'fields': ('name',)}),
             ('Permissions', {
                 'fields': (
-                    ('is_active', 'email_verification_required'),
+                    ('is_active', 'email_verified'),
                     'is_staff',
                     'is_superuser',
                     'groups',

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -40,7 +40,7 @@ class TestUser(utils.APIRequestTestCase):
             'name',
             'date_joined',
             'email',
-            'email_verification_required',
+            'email_verified',
             'is_active',
             'is_staff',
             'is_superuser',
@@ -115,7 +115,7 @@ class TestUserManager(TestCase):
         self.assertFalse(user.is_active)
         self.assertFalse(user.is_staff)
         self.assertFalse(user.is_superuser)
-        self.assertTrue(user.email_verification_required)
+        self.assertFalse(user.email_verified)
 
         # Check that the time is correct (or at least, in range)
         time_after = timezone.now()
@@ -175,7 +175,7 @@ class TestVerifyEmailMixin(TestCase):
         user = self.model()
         user.save()
         self.assertFalse(user.is_active)
-        self.assertTrue(user.email_verification_required)
+        self.assertFalse(user.email_verified)
 
     def test_email_context(self):
         """Assert `email_context` returns the correct data."""
@@ -217,7 +217,7 @@ class TestVerifyEmailMixin(TestCase):
         send.assert_called_once_with(**expected)
 
     def test_verified_email(self):
-        user = self.model(email_verification_required=False)
+        user = self.model(email_verified=True)
 
         with patch(SEND_METHOD) as send:
             with self.assertRaises(ValueError):
@@ -259,7 +259,7 @@ class TestCustomNameUser(utils.APIRequestTestCase):
             'name',
             'date_joined',
             'email',
-            'email_verification_required',
+            'email_verified',
             'is_active',
             'is_staff',
             'last_login',


### PR DESCRIPTION
The variable `User.email_verification_required` is named based upon the presumption that email verification is required when it is possible, and becomes a confusing variable name when applied outside of this context.

Instead of modelling this presumption, we should instead be representing the raw information in the database. To that end, I propose that we rename the boolean to `email_verified`, as that better represents the information that we need to store.

This will require a migration of the values, as when `email_verified==True`, `email_verification_required==False` and vice versa.