### PR TITLE
Untie password confirmation from email verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v10.0.0 (Upcoming)
+
+* Replace `default_token_generator` with `django.core.signing`.
+
+### Notes
+
+* Previously not validated emails would be invalid.
+
 ## v9.0.1
 
 * Send `user_logged_in` and `user_logged_out` signals from `GetAuthToken` view.

--- a/user_management/api/templates/user_management/account_validation_email.html
+++ b/user_management/api/templates/user_management/account_validation_email.html
@@ -4,7 +4,7 @@ register an account at {{ name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
-{{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
+{{ protocol }}://{{ site.domain }}/#/register/verify/{{ token }}/
 
 {% blocktrans with name=site.name %}
 The {{ name }} team.

--- a/user_management/api/templates/user_management/account_validation_email.txt
+++ b/user_management/api/templates/user_management/account_validation_email.txt
@@ -4,7 +4,7 @@ register an account at {{ name }}.
 
 Please click the following link to complete your registration:
 {% endblocktrans %}
-{{ protocol }}://{{ site.domain }}/#/register/verify/{{ uid }}/{{ token }}/
+{{ protocol }}://{{ site.domain }}/#/register/verify/{{ token }}/
 
 {% blocktrans with name=site.name %}
 The {{ name }} team.

--- a/user_management/api/tests/test_urls.py
+++ b/user_management/api/tests/test_urls.py
@@ -58,13 +58,12 @@ class TestURLs(URLTestCase):
 
     def test_verify_email(self):
         """Assert `verify_user` is defined."""
-        uidb64 = '123'
         token = 'a-token'
         self.assert_url_matches_view(
             view=views.VerifyAccountView,
-            expected_url='/verify_email/{}/{}'.format(uidb64, token),
+            expected_url='/verify_email/{}'.format(token),
             url_name='user_management_api:verify_user',
-            url_kwargs={'uidb64': uidb64, 'token': token},
+            url_kwargs={'token': token},
         )
 
     def test_resend_confirmation_email(self):

--- a/user_management/api/urls/verify_email.py
+++ b/user_management/api/urls/verify_email.py
@@ -8,8 +8,7 @@ urlpatterns = patterns(
     '',
     url(
         regex=(
-            r'^verify_email/(?P<uidb64>[0-9A-Za-z_\-]+)/'
-            r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/?$'
+            r'^verify_email/(?P<token>[0-9A-Za-z:\-_]+)/?$'
         ),
         view=csrf_exempt(views.VerifyAccountView.as_view()),
         name='verify_user',

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -221,6 +221,11 @@ class VerifyAccountView(views.APIView):
     ok_message = _('Your account has been verified.')
 
     def initial(self, request, *args, **kwargs):
+        """
+        Use `token` to allow one-time access to a view.
+
+        Set user as a class attribute or raise an `InvalidExpiredToken`.
+        """
         try:
             email_data = signing.loads(kwargs['token'])
         except signing.BadSignature:

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model, signals
 from django.contrib.auth.tokens import default_token_generator
+from django.core import signing
 from django.utils.encoding import force_text
 from django.utils.http import urlsafe_base64_decode
 from django.utils.translation import ugettext_lazy as _
@@ -210,7 +211,7 @@ class PasswordChange(generics.UpdateAPIView):
         return self.request.user
 
 
-class VerifyAccountView(OneTimeUseAPIMixin, views.APIView):
+class VerifyAccountView(views.APIView):
     """
     Verify a new user's email address.
 
@@ -218,6 +219,25 @@ class VerifyAccountView(OneTimeUseAPIMixin, views.APIView):
     """
     permission_classes = [AllowAny]
     ok_message = _('Your account has been verified.')
+
+    def initial(self, request, *args, **kwargs):
+        try:
+            email_data = signing.loads(kwargs['token'])
+        except signing.BadSignature:
+            raise exceptions.InvalidExpiredToken
+
+        email = email_data['email']
+
+        try:
+            self.user = User.objects.get_by_natural_key(email)
+        except User.DoesNotExist:
+            raise exceptions.InvalidExpiredToken()
+
+        return super(VerifyAccountView, self).initial(
+            request,
+            *args,
+            **kwargs
+        )
 
     def post(self, request, *args, **kwargs):
         if self.user.email_verified:

--- a/user_management/models/mixins.py
+++ b/user_management/models/mixins.py
@@ -1,7 +1,7 @@
 from django.contrib.auth.models import BaseUserManager
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
-from django.core import checks
+from django.core import checks, signing
 from django.db import models
 from django.utils import timezone
 from django.utils.encoding import force_bytes, python_2_unicode_compatible
@@ -138,12 +138,17 @@ class EmailVerifyUserMethodsMixin:
     password_reset_notification = notifications.PasswordResetNotification
     validation_notification = notifications.ValidationNotification
 
-    def generate_token(self):
+    def generate_validation_token(self):
         """Generate user token for account validation."""
+        data = {'email': self.email}
+        return signing.dumps(data)
+
+    def generate_token(self):
+        """Generate user token for password reset."""
         return default_token_generator.make_token(self)
 
     def generate_uid(self):
-        """Generate user uid for account validation."""
+        """Generate user uid for password reset."""
         return urlsafe_base64_encode(force_bytes(self.pk))
 
     def send_validation_email(self):

--- a/user_management/models/tests/test_models.py
+++ b/user_management/models/tests/test_models.py
@@ -12,13 +12,14 @@ from django.utils import six, timezone
 from mock import Mock, patch
 
 from user_management.models.tests import utils
-from user_management.utils.notifications import email_context
+from user_management.utils.notifications import validation_email_context
 from . import models
 from .factories import UserFactory
 from .. import mixins
 
 
-EMAIL_CONTEXT = 'user_management.utils.notifications.email_context'
+PASSWORD_CONTEXT = 'user_management.utils.notifications.password_reset_email_context'
+VALIDATION_CONTEXT = 'user_management.utils.notifications.validation_email_context'
 SEND_METHOD = 'user_management.utils.notifications.incuna_mail.send'
 
 skip_if_checks_unavailable = unittest.skipIf(
@@ -178,7 +179,7 @@ class TestVerifyEmailMixin(TestCase):
         self.assertFalse(user.email_verified)
 
     def test_email_context(self):
-        """Assert `email_context` returns the correct data."""
+        """Assert `password_reset_email_context` returns the correct data."""
         mocked_user = Mock()
         mocked_site = Mock()
 
@@ -187,12 +188,11 @@ class TestVerifyEmailMixin(TestCase):
             site = mocked_site
 
         notification = DummyNotification()
-        context = email_context(notification)
+        context = validation_email_context(notification)
 
         expected_context = {
             'protocol': 'https',
-            'uid': mocked_user.generate_uid(),
-            'token': mocked_user.generate_token(),
+            'token': mocked_user.generate_validation_token(),
             'site': mocked_site,
         }
         self.assertEqual(context, expected_context)
@@ -202,7 +202,7 @@ class TestVerifyEmailMixin(TestCase):
         site = Site.objects.get_current()
         user = self.model(email='email@email.email')
 
-        with patch(EMAIL_CONTEXT) as get_context:
+        with patch(VALIDATION_CONTEXT) as get_context:
             get_context.return_value = context
             with patch(SEND_METHOD) as send:
                 user.send_validation_email()
@@ -294,7 +294,7 @@ class TestCustomPasswordResetNotification(TestCase):
         site = Site.objects.get_current()
         user = self.model(email='email@email.email')
 
-        with patch(EMAIL_CONTEXT) as get_context:
+        with patch(PASSWORD_CONTEXT) as get_context:
             get_context.return_value = context
             with patch(SEND_METHOD) as send:
                 user.send_password_reset()

--- a/user_management/utils/notifications.py
+++ b/user_management/utils/notifications.py
@@ -3,7 +3,8 @@ from django.utils.translation import ugettext_lazy as _
 from pigeon.notification import Notification
 
 
-def email_context(notification):
+def password_reset_email_context(notification):
+    """Email context to reset a user password."""
     return {
         'protocol': 'https',
         'uid': notification.user.generate_uid(),
@@ -12,7 +13,16 @@ def email_context(notification):
     }
 
 
-def email_handler(notification):
+def validation_email_context(notification):
+    """Email context to verify a user email."""
+    return {
+        'protocol': 'https',
+        'token': notification.user.generate_validation_token(),
+        'site': notification.site,
+    }
+
+
+def email_handler(notification, email_context):
     """Send a notification by email."""
     incuna_mail.send(
         to=notification.user.email,
@@ -27,14 +37,14 @@ def password_reset_email_handler(notification):
     """Password reset email handler."""
     subject = _('{domain} password reset').format(domain=notification.site.domain)
     notification.email_subject = subject
-    email_handler(notification)
+    email_handler(notification, password_reset_email_context)
 
 
 def validation_email_handler(notification):
     """Validation email handler."""
     subject = _('{domain} account validate').format(domain=notification.site.domain)
     notification.email_subject = subject
-    email_handler(notification)
+    email_handler(notification, validation_email_context)
 
 
 class PasswordResetNotification(Notification):


### PR DESCRIPTION
A user can validate its email in two different ways:
* before being able to log in
* after having logged in

The project uses `django.contrib.auth.tokens.default_token_generator` for both resetting and validating emails. 

When the user needs or validates its email before logging in, everything work as expected however once the user is logged in the validation is failing as `PasswordResetTokenGenerator` checks the token against the user last login.

I think it will be probably better to use something else to check the user emai like [django signing](https://docs.djangoproject.com/en/1.7/topics/signing/).