### PR TITLE
ResendConfirmationEmail should allow anonymous and logged in user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v10.1.0 (Upcoming)
+
+* Allow authenticated user to receive a new confirmation email.
+
+### Notes
+
+* Previously only anonymous could request a new confirmation email.
+
 ## v10.0.0
 
 * Replace `default_token_generator` with `django.core.signing`.

--- a/user_management/api/permissions.py
+++ b/user_management/api/permissions.py
@@ -18,3 +18,14 @@ class IsAdminOrReadOnly(BasePermission):
             return True
 
         return request.user.is_staff
+
+
+class IsAnonymousOrOwner(BasePermission):
+    """Check if user is anonymous or if email belongs to user."""
+    def has_permission(self, request, view):
+        if request.user.is_anonymous():
+            return True
+        email = request.DATA.get('email')
+        if not email:
+            return True
+        return request.user.email.lower() == email.lower()

--- a/user_management/api/permissions.py
+++ b/user_management/api/permissions.py
@@ -18,14 +18,3 @@ class IsAdminOrReadOnly(BasePermission):
             return True
 
         return request.user.is_staff
-
-
-class IsAnonymousOrOwner(BasePermission):
-    """Check if user is anonymous or if email belongs to user."""
-    def has_permission(self, request, view):
-        if request.user.is_anonymous():
-            return True
-        email = request.DATA.get('email')
-        if not email:
-            return True
-        return request.user.email.lower() == email.lower()

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -1028,3 +1028,23 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
 
         expected = 'example.com account validate'
         self.assertEqual(email.subject, expected)
+
+    def test_send_email_other_user(self):
+        """Assert a user can not request a confirmation email for another user."""
+        user, other_user = UserFactory.create_batch(2)
+        data = {'email': other_user.email}
+        request = self.create_request('post', user=user, data=data)
+        view = self.view_class.as_view()
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_send_email_empty(self):
+        """Assert we delegate the error to the serializer if no email data was sent."""
+        data = {}
+        request = self.create_request('post', data=data)
+        view = self.view_class.as_view()
+        response = view(request)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('This field is required.', response.data['email'])

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -1046,5 +1046,4 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
         view = self.view_class.as_view()
         response = view(request)
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('This field is required.', response.data['email'])
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -993,11 +993,29 @@ class ResendConfirmationEmailTest(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn('email', response.data)
 
-    def test_send_email(self):
-        """Assert user can receive a new confirmation email."""
+    def test_send_email_unauthenticated(self):
+        """Assert unauthenticated user can receive a new confirmation email."""
         user = UserFactory.create()
         data = {'email': user.email}
         request = self.create_request('post', auth=False, data=data)
+        view = self.view_class.as_view()
+        view(request)
+
+        self.assertEqual(len(mail.outbox), 1)
+        email = mail.outbox[0]
+
+        self.assertIn(user.email, email.to)
+        expected = 'https://example.com/#/register/verify/'
+        self.assertIn(expected, email.body)
+
+        expected = 'example.com account validate'
+        self.assertEqual(email.subject, expected)
+
+    def test_send_email_authenticated(self):
+        """Assert authenticated user can receive a new confirmation email."""
+        user = UserFactory.create()
+        data = {'email': user.email}
+        request = self.create_request('post', user=user, data=data)
         view = self.view_class.as_view()
         view(request)
 

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -301,7 +301,7 @@ class ResendConfirmationEmail(generics.GenericAPIView):
     `POST` request to resend a confirmation email for existing user. Useful when
     the token has expired.
     """
-    permission_classes = [permissions.IsNotAuthenticated]
+    permission_classes = [AllowAny]
     serializer_class = serializers.ResendConfirmationEmailSerializer
     throttle_classes = [throttling.ResendConfirmationEmailRateThrottle]
     throttle_scope = 'confirmations'

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -298,10 +298,10 @@ class ResendConfirmationEmail(generics.GenericAPIView):
     """
     Resend a confirmation email.
 
-    `POST` request to resend a confirmation email for existing user. Useful when
-    the token has expired.
+    `POST` request to resend a confirmation email for existing user. If user is
+    authenticated the email sent should match.
     """
-    permission_classes = [AllowAny]
+    permission_classes = [permissions.IsAnonymousOrOwner]
     serializer_class = serializers.ResendConfirmationEmailSerializer
     throttle_classes = [throttling.ResendConfirmationEmailRateThrottle]
     throttle_scope = 'confirmations'

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -7,6 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework import generics, response, status, views
 from rest_framework.authentication import get_authorization_header
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import AllowAny, IsAuthenticated
 
 from . import exceptions, models, permissions, serializers, throttling
@@ -301,10 +302,26 @@ class ResendConfirmationEmail(generics.GenericAPIView):
     `POST` request to resend a confirmation email for existing user. If user is
     authenticated the email sent should match.
     """
-    permission_classes = [permissions.IsAnonymousOrOwner]
+    permission_classes = [AllowAny]
     serializer_class = serializers.ResendConfirmationEmailSerializer
     throttle_classes = [throttling.ResendConfirmationEmailRateThrottle]
     throttle_scope = 'confirmations'
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Use `token` to allow one-time access to a view.
+
+        Set user as a class attribute or raise an `InvalidExpiredToken`.
+        """
+        email = request.DATA.get('email')
+        if request.user.is_authenticated() and email != request.user.email:
+            raise PermissionDenied()
+
+        return super(ResendConfirmationEmail, self).initial(
+            request,
+            *args,
+            **kwargs
+        )
 
     def post(self, request, *args, **kwargs):
         """Validate `email` and send a request to confirm it."""


### PR DESCRIPTION
In case the user can login but requires to have another confirmation email sent we should be able to do so. I think adding [`AllowAny`](https://github.com/incuna/django-user-management/blob/7da40f402e6e5c678f09de99ea172d2cac94f2f9/user_management/api/views.py#L304) should be enough. We can rely on frontend to send the email of the current user.