### PR TITLE
Remove legacy assert

### DIFF
--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -61,14 +61,12 @@ class GetAuthTokenTest(APIRequestTestCase):
 
     def test_post_last_login_updates(self):
         """Authenticating updates the user's last_login."""
-        now = timezone.now()
         user = UserFactory.create(
             email=self.username,
             password=self.password,
-            last_login=now,
         )
-        self.assertEqual(user.last_login, now)
 
+        now = timezone.now()
         request = self.create_request('post', auth=False, data=self.data)
         self.view_class.as_view()(request)
         user = User.objects.get(pk=user.pk)

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -65,12 +65,13 @@ class GetAuthTokenTest(APIRequestTestCase):
             email=self.username,
             password=self.password,
         )
-
+        previous_last_login = user.last_login
         now = timezone.now()
         request = self.create_request('post', auth=False, data=self.data)
         self.view_class.as_view()(request)
         user = User.objects.get(pk=user.pk)
         self.assertGreater(user.last_login, now)
+        self.assertNotEqual(user.last_login, previous_last_login)
 
     def test_post_non_existing_user(self):
         """Assert non existing raises an error."""


### PR DESCRIPTION
related to https://github.com/incuna/django-user-management/pull/123#issuecomment-108391219
`last_login` sets to now or None is covered in django