### PR TITLE
Hide 'your passwords don't match' for invalid passwords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v8.1.1
+
+* Bugfix: Don't show "passwords do not match" when the first password is invalid.
+
 ## v8.1.0
 
 * Add docstrings for views.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-version = '8.1.0'
+version = '8.1.1'
 
 
 install_requires = (

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -47,8 +47,8 @@ class RegistrationSerializer(ValidateEmailMixin, serializers.ModelSerializer):
         fields = ['name', 'email', 'password', 'password2']
         model = User
 
-    def validate_password2(self, attrs, source):
-        password2 = attrs.pop(source)
+    def validate(self, attrs):
+        password2 = attrs.pop('password2')
         if password2 != attrs.get('password'):
             msg = _('Your passwords do not match.')
             raise serializers.ValidationError(msg)

--- a/user_management/api/tests/test_serializers.py
+++ b/user_management/api/tests/test_serializers.py
@@ -75,8 +75,9 @@ class PasswordChangeSerializerTest(TestCase):
         })
         self.assertFalse(serializer.is_valid())
         self.assertIn('new_password', serializer.errors)
-        self.assertNotIn('Your passwords do not match', serializer.errors)
         self.assertTrue(serializer.object.check_password(old_password))
+        # Assert that there are no spurious password mismatch errors
+        self.assertNotIn('non_field_errors', serializer.errors)
 
     def test_deserialize_mismatched_passwords(self):
         old_password = '0ld_passworD'

--- a/user_management/api/tests/test_serializers.py
+++ b/user_management/api/tests/test_serializers.py
@@ -75,6 +75,7 @@ class PasswordChangeSerializerTest(TestCase):
         })
         self.assertFalse(serializer.is_valid())
         self.assertIn('new_password', serializer.errors)
+        self.assertNotIn('Your passwords do not match', serializer.errors)
         self.assertTrue(serializer.object.check_password(old_password))
 
     def test_deserialize_mismatched_passwords(self):
@@ -161,7 +162,8 @@ class RegistrationSerializerTest(TestCase):
         self.data['password2'] = 'different_password'
         serializer = serializers.RegistrationSerializer(data=self.data)
         self.assertFalse(serializer.is_valid())
-        self.assertIn('password2', serializer.errors)
+        message = 'Your passwords do not match.'
+        self.assertIn(message, serializer.errors['non_field_errors'])
 
     def test_deserialize_no_email(self):
         self.data['email'] = None

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -238,7 +238,7 @@ class TestRegisterView(APIRequestTestCase):
         request = self.create_request('post', auth=False, data=self.data)
         response = self.view_class.as_view()(request)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('password2', response.data)
+        self.assertIn('Your passwords do not match.', response.data['non_field_errors'])
 
         self.assertFalse(User.objects.count())
 


### PR DESCRIPTION
@incuna/backend review please?

This is a fix for version 8.1.0, for a project that doesn't want to update to DRF 3 or any of that complicated stuff.  Please don't merge (even if GitHub lets you, which it hopefully won't :P).  I'll release from this branch when review is done.