### PR TITLE
Make all fields a tuple in serializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v13.0.0 (upcoming)
+
+* Make `RegistrationSerializer` and `EmailSerializerBase` fields a tuple.
+
 ## v12.0.1
 
 * Ensure new and old passwords differ when changing password.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 * Make `RegistrationSerializer` and `EmailSerializerBase` fields a tuple.
 
+### Notes
+
+`RegistrationSerializer` or `EmailSerializerBase` subclasses adding new fields
+with a `list` will generate a `TypeError`:
+
+```
+class CustomRegistration(RegistrationSerializer):
+    class Meta(RegistrationSerializer.Meta):
+        fields = RegistrationSerializer.Meta.fields + ['custom_field']
+
+TypeError: can only concatenate tuple (not "list") to tuple`
+```
+
+To fix the previous error we use a tuple instead:
+
+```
+class CustomRegistration(RegistrationSerializer):
+    class Meta(RegistrationSerializer.Meta):
+        fields = RegistrationSerializer.Meta.fields + ('custom_field',)
+```
+
 ## v12.0.1
 
 * Ensure new and old passwords differ when changing password.

--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -33,7 +33,7 @@ class EmailSerializerBase(serializers.Serializer):
     email = serializers.EmailField(max_length=511, label=_('Email address'))
 
     class Meta:
-        fields = ['email']
+        fields = ('email',)
 
 
 class RegistrationSerializer(ValidateEmailMixin, serializers.ModelSerializer):
@@ -51,7 +51,7 @@ class RegistrationSerializer(ValidateEmailMixin, serializers.ModelSerializer):
     )
 
     class Meta:
-        fields = ['name', 'email', 'password', 'password2']
+        fields = ('name', 'email', 'password', 'password2')
         model = User
 
     def validate(self, attrs):


### PR DESCRIPTION
If in a project we define a tuple of core fields and try to concatenate
them with the original serializer fields we need to add an exception to
`RegistrationSerializer`.

Making all fields a tuple allow to subclass them more easily.