### PR TITLE
Make token expires for AccountVerifyView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v13.1.0
+
+* Make token to verify account to expires if `VERIFY_ACCOUNT_EXPIRY` is set to
+a value in seconds.
+
+### Notes
+
+* If `VERIFY_ACCOUNT_EXPIRY` is not set the token will never expire.
+
 ## v13.0.0
 
 * Make `RegistrationSerializer` and `EmailSerializerBase` fields a tuple.

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
-from django.test import override_settings
+from django.test.utils import override_settings
 from django.utils import timezone
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
@@ -678,7 +678,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_default_expiry_token(self):
-        """Assert `DEFAULT_VERIFY_ACCOUNT_EXPIRY` is used by default."""
+        """Assert `DEFAULT_VERIFY_ACCOUNT_EXPIRY` doesn't expire by default."""
         user = UserFactory.create()
         token = user.generate_validation_token()
         request = self.create_request('post', auth=False)
@@ -687,8 +687,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         with patch('django.core.signing.loads') as signing_loads:
             view(request, token=token)
 
-        expected_age = 60 * 60 * 24 * 31
-        signing_loads.assert_called_once_with(token, max_age=expected_age)
+        signing_loads.assert_called_once_with(token, max_age=None)
 
     @override_settings(VERIFY_ACCOUNT_EXPIRY=0)
     def test_post_expired_token(self):

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -685,6 +685,7 @@ class TestVerifyAccountView(APIRequestTestCase):
         view = self.view_class.as_view()
 
         with patch('django.core.signing.loads') as signing_loads:
+            signing_loads.return_value = {'email': user.email}
             view(request, token=token)
 
         signing_loads.assert_called_once_with(token, max_age=None)

--- a/user_management/api/tests/test_views.py
+++ b/user_management/api/tests/test_views.py
@@ -9,6 +9,7 @@ from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.cache import cache
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 from django.utils import timezone
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
@@ -674,6 +675,31 @@ class TestVerifyAccountView(APIRequestTestCase):
         request = self.create_request('post')
         view = self.view_class.as_view()
         response = view(request, token=token)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_default_expiry_token(self):
+        """Assert `DEFAULT_VERIFY_ACCOUNT_EXPIRY` is used by default."""
+        user = UserFactory.create()
+        token = user.generate_validation_token()
+        request = self.create_request('post', auth=False)
+        view = self.view_class.as_view()
+
+        with patch('django.core.signing.loads') as signing_loads:
+            view(request, token=token)
+
+        expected_age = 60 * 60 * 24 * 31
+        signing_loads.assert_called_once_with(token, max_age=expected_age)
+
+    @override_settings(VERIFY_ACCOUNT_EXPIRY=0)
+    def test_post_expired_token(self):
+        """Assert token expires."""
+        user = UserFactory.create()
+        token = user.generate_validation_token()
+        request = self.create_request('post', auth=False)
+        view = self.view_class.as_view()
+
+        response = view(request, token=token)
+
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_post_verified_email(self):

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -218,12 +218,15 @@ class VerifyAccountView(views.APIView):
     """
     permission_classes = [AllowAny]
     ok_message = _('Your account has been verified.')
-    # Default token expiry sets to 31 days in seconds
-    DEFAULT_VERIFY_ACCOUNT_EXPIRY = 60 * 60 * 24 * 31
+    # Default token never expires.
+    DEFAULT_VERIFY_ACCOUNT_EXPIRY = None
 
     def initial(self, request, *args, **kwargs):
         """
         Use `token` to allow one-time access to a view.
+
+        Token expiry can be set in `settings` with `VERIFY_ACCOUNT_EXPIRY` and is
+        set in seconds.
 
         Set user as a class attribute or raise an `InvalidExpiredToken`.
         """

--- a/user_management/api/views.py
+++ b/user_management/api/views.py
@@ -230,11 +230,10 @@ class VerifyAccountView(views.APIView):
 
         Set user as a class attribute or raise an `InvalidExpiredToken`.
         """
-        max_age = getattr(
-            settings,
-            'VERIFY_ACCOUNT_EXPIRY',
-            self.DEFAULT_VERIFY_ACCOUNT_EXPIRY,
-        )
+        try:
+            max_age = settings.VERIFY_ACCOUNT_EXPIRY
+        except AttributeError:
+            max_age = self.DEFAULT_VERIFY_ACCOUNT_EXPIRY
 
         try:
             email_data = signing.loads(kwargs['token'], max_age=max_age)


### PR DESCRIPTION
[By default](https://github.com/django/django/blob/0e925de245a0a1bf5d063c816c8bff9f0280a4c7/django/core/signing.py#L134) `signing.loads` has `max_age` sets to `None` which makes the
token to validate an account to never expire.