### PR TITLE
Clarify new password error message

### DIFF
--- a/user_management/api/serializers.py
+++ b/user_management/api/serializers.py
@@ -105,7 +105,7 @@ class PasswordChangeSerializer(serializers.ModelSerializer):
             msg = _('Your new passwords do not match.')
             raise serializers.ValidationError({'new_password2': msg})
         if attrs.get('old_password') == attrs.get('new_password'):
-            msg = _('Your password has not changed.')
+            msg = _('Your new password must not be the same as your old password.')
             raise serializers.ValidationError({'new_password': msg})
         return attrs
 


### PR DESCRIPTION
"Your password has not changed" might imply there was an error changing your password, rather than you didn't change it.

@incuna/frontend please review