### PR TITLE
Split the bulk of VerifyAccountView off into a mixin

### DIFF
--- a/user_management/utils/tests/test_views.py
+++ b/user_management/utils/tests/test_views.py
@@ -1,0 +1,81 @@
+import mock
+from django.contrib.auth import get_user_model
+from django.test import override_settings
+
+from user_management.models.tests.factories import VerifyEmailUserFactory
+from user_management.models.tests.utils import APIRequestTestCase
+from .. import views
+
+User = get_user_model()
+
+
+class FakeViewSuperclass(object):
+    """
+    initial() on APIView is a pain, so here's the easiest way to get the super call
+    in VerifyAccountViewMixin.initial() working.
+    """
+    def initial(self, request, *args, **kwargs):
+        pass
+
+
+class FakeVerifyView(views.VerifyAccountViewMixin, FakeViewSuperclass):
+    """A minimal subclass of the mixin for testing."""
+
+
+@override_settings(AUTH_USER_MODEL='tests.VerifyEmailUser')
+class TestVerifyAccountView(APIRequestTestCase):
+    view_class = FakeVerifyView
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.request = mock.MagicMock
+        cls.view_instance = cls.view_class()
+        cls.user = VerifyEmailUserFactory.create(email_verified=False)
+        cls.token = cls.user.generate_validation_token()
+
+    def test_initial_allowed(self):
+        """Assert a user can verify its own email."""
+        self.view_instance.initial(self.request, token=self.token)
+        self.assertEqual(self.view_instance.user, self.user)
+
+    def test_initial_invalid_user(self):
+        """Assert a nonexistent user throws an exception."""
+        user = VerifyEmailUserFactory.build()
+        token = user.generate_validation_token()
+        with self.assertRaises(self.view_instance.invalid_exception_class):
+            self.view_instance.initial(self.request, token=token)
+
+    def test_initial_invalid_token(self):
+        """Assert forged token return a bad request."""
+        token = 'nimporte-nawak'
+        with self.assertRaises(self.view_instance.invalid_exception_class):
+            self.view_instance.initial(self.request, token=token)
+
+    def test_default_expiry_token(self):
+        """Assert `DEFAULT_VERIFY_ACCOUNT_EXPIRY` doesn't expire by default."""
+        with mock.patch('django.core.signing.loads') as signing_loads:
+            signing_loads.return_value = {'email': self.user.email}
+            self.view_instance.initial(self.request, token=self.token)
+
+        signing_loads.assert_called_once_with(self.token, max_age=None)
+
+    @override_settings(VERIFY_ACCOUNT_EXPIRY=0)
+    def test_initial_expired_token(self):
+        """Assert token expires when VERIFY_ACCOUNT_EXPIRY is set."""
+        with self.assertRaises(self.view_instance.invalid_exception_class):
+            self.view_instance.initial(self.request, token=self.token)
+
+    def test_initial_verified_email(self):
+        """Assert verified user cannot verify email."""
+        user = VerifyEmailUserFactory.create(email_verified=True)
+        token = user.generate_validation_token()
+        with self.assertRaises(self.view_instance.permission_denied_class):
+            self.view_instance.initial(self.request, token=token)
+
+    def test_activate_user(self):
+        user = VerifyEmailUserFactory.create(email_verified=False, is_active=False)
+        self.view_instance.user = user
+
+        self.view_instance.activate_user()
+        self.assertTrue(user.email_verified)
+        self.assertTrue(user.is_active)

--- a/user_management/utils/views.py
+++ b/user_management/utils/views.py
@@ -1,0 +1,59 @@
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.core import signing
+from django.utils.translation import ugettext_lazy as _
+from rest_framework.exceptions import PermissionDenied
+
+from user_management.api.exceptions import InvalidExpiredToken
+
+
+class VerifyAccountViewMixin():
+    """
+    Verify a new user's email address.
+
+    Verify a newly created account by checking the `token` in the URL kwargs.
+    """
+    ok_message = _('Your account has been verified.')
+    invalid_exception_class = InvalidExpiredToken
+    permission_denied_class = PermissionDenied
+
+    # Default token never expires.
+    DEFAULT_VERIFY_ACCOUNT_EXPIRY = None
+
+    def initial(self, request, *args, **kwargs):
+        """
+        Use `token` to allow one-time access to a view.
+
+        Set the user as a class attribute or raise an `InvalidExpiredToken`.
+
+        Token expiry can be set in `settings` with `VERIFY_ACCOUNT_EXPIRY` and is
+        set in seconds.
+        """
+        User = get_user_model()
+
+        try:
+            max_age = settings.VERIFY_ACCOUNT_EXPIRY
+        except AttributeError:
+            max_age = self.DEFAULT_VERIFY_ACCOUNT_EXPIRY
+
+        try:
+            email_data = signing.loads(kwargs['token'], max_age=max_age)
+        except signing.BadSignature:
+            raise self.invalid_exception_class
+
+        email = email_data['email']
+
+        try:
+            self.user = User.objects.get_by_natural_key(email)
+        except User.DoesNotExist:
+            raise self.invalid_exception_class
+
+        if self.user.email_verified:
+            raise self.permission_denied_class
+
+        return super(VerifyAccountViewMixin, self).initial(request, *args, **kwargs)
+
+    def activate_user(self):
+        self.user.email_verified = True
+        self.user.is_active = True
+        self.user.save()

--- a/user_management/utils/views.py
+++ b/user_management/utils/views.py
@@ -7,7 +7,7 @@ from rest_framework.exceptions import PermissionDenied
 from user_management.api.exceptions import InvalidExpiredToken
 
 
-class VerifyAccountViewMixin():
+class VerifyAccountViewMixin(object):
     """
     Verify a new user's email address.
 


### PR DESCRIPTION
Turns out DUM had a `VerifyAccountView` in it after all!  This PR splits most of it off into a mixin in order to reimplement the non-API version I added the other day.

@incuna/backend review please?