### PR TITLE
Remove patterns from urls

### DIFF
--- a/user_management/api/avatar/urls/__init__.py
+++ b/user_management/api/avatar/urls/__init__.py
@@ -1,8 +1,7 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'', include('user_management.api.avatar.urls.profile_avatar')),
     url(r'', include('user_management.api.avatar.urls.user_avatar')),
-)
+]

--- a/user_management/api/avatar/urls/user_avatar.py
+++ b/user_management/api/avatar/urls/user_avatar.py
@@ -1,13 +1,12 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=r'^users/(?P<pk>\d+)/avatar/?$',
         view=views.UserAvatar.as_view(),
         name='user_avatar',
     ),
-)
+]

--- a/user_management/api/urls/__init__.py
+++ b/user_management/api/urls/__init__.py
@@ -1,10 +1,9 @@
-from django.conf.urls import include, patterns, url
+from django.conf.urls import include, url
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'', include('user_management.api.urls.auth')),
     url(r'', include('user_management.api.urls.password_reset')),
     url(r'', include('user_management.api.urls.profile')),
     url(r'', include('user_management.api.urls.register')),
-)
+]

--- a/user_management/api/urls/auth.py
+++ b/user_management/api/urls/auth.py
@@ -1,13 +1,12 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=r'^auth/?$',
         view=views.GetAuthToken.as_view(),
         name='auth',
     ),
-)
+]

--- a/user_management/api/urls/password_reset.py
+++ b/user_management/api/urls/password_reset.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=(
             r'^auth/password_reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/'
@@ -19,4 +18,4 @@ urlpatterns = patterns(
         view=views.PasswordResetEmail.as_view(),
         name='password_reset',
     ),
-)
+]

--- a/user_management/api/urls/profile.py
+++ b/user_management/api/urls/profile.py
@@ -1,11 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
-
+urlpatterns = [
     url(
         regex=r'^profile/?$',
         view=views.ProfileDetail.as_view(),
@@ -16,4 +14,4 @@ urlpatterns = patterns(
         view=views.PasswordChange.as_view(),
         name='password_change',
     ),
-)
+]

--- a/user_management/api/urls/register.py
+++ b/user_management/api/urls/register.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=r'^register/?$',
         view=views.UserRegister.as_view(),
@@ -15,4 +14,4 @@ urlpatterns = patterns(
         view=views.ResendConfirmationEmail.as_view(),
         name='resend_confirmation_email',
     ),
-)
+]

--- a/user_management/api/urls/users.py
+++ b/user_management/api/urls/users.py
@@ -1,10 +1,9 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=r'^users/?$',
         view=views.UserList.as_view(),
@@ -15,4 +14,4 @@ urlpatterns = patterns(
         view=views.UserDetail.as_view(),
         name='user_detail'
     ),
-)
+]

--- a/user_management/api/urls/verify_email.py
+++ b/user_management/api/urls/verify_email.py
@@ -1,11 +1,10 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.views.decorators.csrf import csrf_exempt
 
 from .. import views
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(
         regex=(
             r'^verify_email/(?P<token>[0-9A-Za-z:\-_]+)/?$'
@@ -13,4 +12,4 @@ urlpatterns = patterns(
         view=csrf_exempt(views.VerifyAccountView.as_view()),
         name='verify_user',
     ),
-)
+]


### PR DESCRIPTION
`patterns` has been removed in 1.10
see https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10