### PR TITLE
Remove redirect_to_login from VerifyUserEmailView.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UPCOMING
 
-* Update `VerifyUserEmailView` to use LOGIN_REDIRECT_URL rather than `/` as the next url after the login redirect.
+* Update `VerifyUserEmailView` to redirect to login without providing a next.
 
 ## 15.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## UPCOMING
+
+* Update `VerifyUserEmailView` to use LOGIN_REDIRECT_URL rather than `/` as the next url after the login redirect.
+
 ## 15.0.0
 
 * Updated for compatibility with Python 3.5 and Django 1.10

--- a/user_management/ui/tests/test_views.py
+++ b/user_management/ui/tests/test_views.py
@@ -1,7 +1,4 @@
-from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.test import override_settings
-from django.test.utils import override_script_prefix
 
 from user_management.models.tests.factories import VerifyEmailUserFactory
 from user_management.models.tests.models import VerifyEmailUser
@@ -23,8 +20,7 @@ class TestVerifyUserEmailView(RequestTestCase):
         response = view(request, token=token)
         self.assertEqual(response.status_code, 302)
 
-        expected_url = '{}?next={}'.format(settings.LOGIN_URL, settings.LOGIN_REDIRECT_URL)
-        self.assertEqual(response.url, expected_url)
+        self.assertEqual(response.url, '/accounts/login/')
 
         user = VerifyEmailUser.objects.get(pk=user.pk)
 
@@ -35,24 +31,6 @@ class TestVerifyUserEmailView(RequestTestCase):
             self.view_class.success_message,
             str(request._messages.store[0]),
         )
-
-    @override_settings(LOGIN_REDIRECT_URL='user_management_api:profile_detail')
-    @override_script_prefix('/blah/')
-    def test_get_prefix(self):
-        """Regression test to ensure that the login redirect uses SCRIPT_NAME prefix."""
-        user = VerifyEmailUserFactory.create(email_verified=False)
-        token = user.generate_validation_token()
-
-        request = self.create_request('get', auth=False)
-
-        view = self.view_class.as_view()
-        response = view(request, token=token)
-        self.assertEqual(response.status_code, 302)
-
-        login_redirect_url = reverse(settings.LOGIN_REDIRECT_URL)
-        self.assertIn('/blah/', login_redirect_url)
-        expected_url = '{}?next={}'.format(settings.LOGIN_URL, login_redirect_url)
-        self.assertEqual(response.url, expected_url)
 
     def test_get_nonsense_token(self):
         """The view is accessed with a broken token and 404s."""

--- a/user_management/ui/views.py
+++ b/user_management/ui/views.py
@@ -1,8 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
-from django.shortcuts import resolve_url
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
@@ -34,7 +32,6 @@ class VerifyUserEmailView(VerifyAccountViewMixin, generic.RedirectView):
         return super(VerifyUserEmailView, self).dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        next = resolve_url(settings.LOGIN_REDIRECT_URL)
         self.activate_user()
         messages.success(request, self.success_message)
-        return redirect_to_login(next, login_url=self.url)
+        return super(VerifyUserEmailView, self).get(request, *args, **kwargs)

--- a/user_management/ui/views.py
+++ b/user_management/ui/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
+from django.shortcuts import resolve_url
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
@@ -33,6 +34,7 @@ class VerifyUserEmailView(VerifyAccountViewMixin, generic.RedirectView):
         return super(VerifyUserEmailView, self).dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
+        next = resolve_url(settings.LOGIN_REDIRECT_URL)
         self.activate_user()
         messages.success(request, self.success_message)
-        return redirect_to_login('/', login_url=self.url)
+        return redirect_to_login(next, login_url=self.url)

--- a/user_management/ui/views.py
+++ b/user_management/ui/views.py
@@ -17,12 +17,10 @@ class VerifyUserEmailView(VerifyAccountViewMixin, generic.RedirectView):
     object, for verification.  If everything lines up, it makes the user
     active.
 
-    As a RedirectView, this will return a HTTP 302 on success.  This defaults to
-    `/` but can be overridden by changing the `url` attribute in a subclass or setting
-    LOGIN_URL in your settings.
+    As a RedirectView, this will return a HTTP 302 to LOGIN_URL on success.
     """
     permanent = False
-    url = getattr(settings, 'LOGIN_URL', '/')
+    url = settings.LOGIN_URL
     success_message = _('Your email address was confirmed.')
     invalid_exception_class = InvalidExpiredToken
     permission_denied_class = PermissionDenied


### PR DESCRIPTION
Update VerifyUserEmailView to use LOGIN_REDIRECT_URL rather than `/` as the `next` url after the login redirect.