### PR TITLE
Redirect to login when email is already verifyed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## UPCOMING
 
 * Update `VerifyUserEmailView` to redirect to login without providing a next.
+* Redirect to the login when attempting to verify an email address that is already verified.
 
 ## 15.0.0
 

--- a/user_management/ui/exceptions.py
+++ b/user_management/ui/exceptions.py
@@ -5,3 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 class InvalidExpiredToken(Http404):
     """Exception to confirm an account."""
     message = _('Invalid or expired token.')
+
+
+class AlreadyVerifiedException(Exception):
+    message = _('Email already verified.')

--- a/user_management/ui/views.py
+++ b/user_management/ui/views.py
@@ -1,11 +1,10 @@
 from django.conf import settings
 from django.contrib import messages
-from django.core.exceptions import PermissionDenied
 from django.utils.translation import ugettext_lazy as _
 from django.views import generic
 
 from user_management.utils.views import VerifyAccountViewMixin
-from .exceptions import InvalidExpiredToken
+from .exceptions import AlreadyVerifiedException, InvalidExpiredToken
 
 
 class VerifyUserEmailView(VerifyAccountViewMixin, generic.RedirectView):
@@ -20,16 +19,23 @@ class VerifyUserEmailView(VerifyAccountViewMixin, generic.RedirectView):
     As a RedirectView, this will return a HTTP 302 to LOGIN_URL on success.
     """
     permanent = False
+    already_verified = False
     url = settings.LOGIN_URL
     success_message = _('Your email address was confirmed.')
+    already_verified_message = _('Your email is already confirmed.')
     invalid_exception_class = InvalidExpiredToken
-    permission_denied_class = PermissionDenied
+    permission_denied_class = AlreadyVerifiedException
 
     def dispatch(self, request, *args, **kwargs):
-        self.verify_token(request, *args, **kwargs)
+        try:
+            self.verify_token(request, *args, **kwargs)
+        except self.permission_denied_class:
+            self.already_verified = True
+            self.success_message = self.already_verified_message
         return super(VerifyUserEmailView, self).dispatch(request, *args, **kwargs)
 
     def get(self, request, *args, **kwargs):
-        self.activate_user()
+        if not self.already_verified:
+            self.activate_user()
         messages.success(request, self.success_message)
         return super(VerifyUserEmailView, self).get(request, *args, **kwargs)


### PR DESCRIPTION
Redirect to the login when attempting to verify an email address that is already verified.

This avoids presenting the user with a `403 Forbidden` error when the they click the email verification link a second time.
